### PR TITLE
Update NNP to 1.1.0 and add translation keys

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -774,10 +774,10 @@
 		"fileID": 4515377,
 		"required": true
 	},
-    	{
-        	"projectID": 870486,
-		"fileID": 4568563,
+	{
+		"projectID": 870486,
+		"fileID": 4569618,
 		"required": true
-    	}
+    }
   ]
 }

--- a/overrides/config/nonetherportals.cfg
+++ b/overrides/config/nonetherportals.cfg
@@ -1,0 +1,6 @@
+# Configuration file
+
+general {
+    # The message to be displayed when portals are disabled. Can be a translation key.
+    S:portalMessage=nomifactory.nonetherportals
+}

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -13,4 +13,4 @@ metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
 metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
 metaitem.quantumstar.name=§5Quantum Star
 
-nomifactory.nonetherportals=Nether portals are disabled in §5Nomifactory§r. Follow the quest book to unlock §6Nether Cakes§r!
+nomifactory.nonetherportals=Nether portals are disabled in §5Nomi-CEu§r. Follow the quest book to unlock §6Nether Cakes§r!

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -12,3 +12,5 @@ metaitem.circuit.wetware_assembly.name=Wetware Processor
 metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
 metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
 metaitem.quantumstar.name=§5Quantum Star
+
+nomifactory.nonetherportals=Nether portals are disabled in §5Nomifactory§r. Follow the quest book to unlock §6Nether Cakes§r!

--- a/overrides/resources/modpack/lang/ru_ru.lang
+++ b/overrides/resources/modpack/lang/ru_ru.lang
@@ -13,4 +13,4 @@ metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
 metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
 metaitem.quantumstar.name=§5Quantum Star
 
-nomifactory.nonetherportals=Порталы Нижнего мира отключены в §5Nomifactory§r, вам необходимо создать §6Торт Нижнего мираs§r. Используйте квест-бук!
+nomifactory.nonetherportals=Порталы Нижнего мира отключены в §5Nomi-CEu§r, вам необходимо создать §6Торт Нижнего мираs§r. Используйте квест-бук!

--- a/overrides/resources/modpack/lang/ru_ru.lang
+++ b/overrides/resources/modpack/lang/ru_ru.lang
@@ -12,3 +12,5 @@ metaitem.circuit.wetware_assembly.name=Wetware Processor
 metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
 metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
 metaitem.quantumstar.name=§5Quantum Star
+
+nomifactory.nonetherportals=Порталы Нижнего мира отключены в §5Nomifactory§r, вам необходимо создать §6Торт Нижнего мираs§r. Используйте квест-бук!

--- a/overrides/resources/modpack/lang/zh_cn.lang
+++ b/overrides/resources/modpack/lang/zh_cn.lang
@@ -12,3 +12,5 @@ metaitem.circuit.wetware_assembly.name=湿件处理器
 metaitem.circuit.wetware_super_computer.name=湿件处理器阵列
 metaitem.circuit.wetware_mainframe.name=湿件处理器主机
 metaitem.quantumstar.name=§5量子之星
+
+nomifactory.nonetherportals=在§5Nomifactory§r中，下界传送门被禁用。按照任务书的指引解锁§6下界蛋糕§r！

--- a/overrides/resources/modpack/lang/zh_cn.lang
+++ b/overrides/resources/modpack/lang/zh_cn.lang
@@ -13,4 +13,4 @@ metaitem.circuit.wetware_super_computer.name=湿件处理器阵列
 metaitem.circuit.wetware_mainframe.name=湿件处理器主机
 metaitem.quantumstar.name=§5量子之星
 
-nomifactory.nonetherportals=在§5Nomifactory§r中，下界传送门被禁用。按照任务书的指引解锁§6下界蛋糕§r！
+nomifactory.nonetherportals=在§5Nomi-CEu§r中，下界传送门被禁用。按照任务书的指引解锁§6下界蛋糕§r！


### PR DESCRIPTION
Updates NNP to 1.1.0 to support notifying nearby players why Nether portals are disabled.

![image](https://github.com/Nomi-CEu/nomi-ceu/assets/22255622/a403a80e-26af-46fd-b3a9-a90a8ad72354)
