### PR TITLE
Implement Ignore Tag

### DIFF
--- a/tools/tasks/changelog/changelogData.ts
+++ b/tools/tasks/changelog/changelogData.ts
@@ -1,5 +1,5 @@
 import { Commit, FixUpInfo, InputReleaseType } from "../../types/changelogTypes";
-import { getLastGitTag, isEnvVariableSet } from "../../util/util";
+import { getLastGitTag, getTags, isEnvVariableSet } from "../../util/util";
 
 export default class ChangelogData {
 	since: string;
@@ -16,7 +16,10 @@ export default class ChangelogData {
 	// Map of a commit SHA to the commits which need to be added to its commit list.
 	combineList: Map<string, Commit[]>;
 
-	constructor() {
+	// Set of tags
+	tags: Set<string>;
+
+	async init(): Promise<void> {
 		this.since = getLastGitTag();
 		this.to = "HEAD";
 
@@ -48,5 +51,7 @@ export default class ChangelogData {
 		this.commitFixes = new Map<string, FixUpInfo>();
 		this.shaList = new Set<string>();
 		this.combineList = new Map<string, Commit[]>();
+
+		this.tags = new Set<string>(await getTags(this.to));
 	}
 }

--- a/tools/tasks/changelog/createChangelog.ts
+++ b/tools/tasks/changelog/createChangelog.ts
@@ -16,7 +16,10 @@ import pushAll from "./pusher";
  */
 async function createChangelog(): Promise<ChangelogData> {
 	const data: ChangelogData = new ChangelogData();
-	changelogSetup(data);
+
+	await data.init();
+	categoriesSetup();
+	specialParserSetup(data);
 
 	for (const parser of parsers) {
 		await parse(data, parser);
@@ -27,11 +30,6 @@ async function createChangelog(): Promise<ChangelogData> {
 	pushAll(data);
 
 	return data;
-}
-
-function changelogSetup(data: ChangelogData) {
-	categoriesSetup();
-	specialParserSetup(data);
 }
 
 /**

--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -1,4 +1,4 @@
-import { Category, Commit, Parser, SubCategory } from "../../types/changelogTypes";
+import { Category, Commit, Ignored, Parser, SubCategory } from "../../types/changelogTypes";
 import { modpackManifest } from "../../globals";
 import { parseCommitBody } from "./parser";
 import { parseFixUp } from "./specialParser";
@@ -26,6 +26,7 @@ export const combineKey = "[COMBINE]";
 export const combineList = "commits";
 export const fixUpKey = "[FIXUP]";
 export const fixUpList = "fixes";
+export const ignoreKey = "[IGNORE]";
 
 /* Sub Category Keys */
 // Mode Category Keys
@@ -121,7 +122,7 @@ const defaultParsingCallback = async (
 	commit: Commit,
 	commitMessage: string,
 	commitBody: string,
-): Promise<boolean> => {
+): Promise<boolean | Ignored> => {
 	if (!commitBody) return false;
 	return parseCommitBody(commitMessage, commitBody, commit, parser);
 };

--- a/tools/tasks/changelog/pusher.ts
+++ b/tools/tasks/changelog/pusher.ts
@@ -35,19 +35,17 @@ export default function pushAll(inputData: ChangelogData): void {
 	});
 
 	// Push the commit log
-	if (data.commitList) {
+	if (data.commitList.length > 0) {
 		sortCommitList(data.commitList, (commit) => commit);
 
 		data.builder.push("## Commits");
 		data.commitList.forEach((commit) => {
 			data.builder.push(formatCommit(commit));
 		});
-	}
-
-	// Check if the builder only contains the title.
-	if (data.builder.length <= 3) {
+	} else {
+		// No Commit List = No Changes
 		data.builder.push("");
-		data.builder.push("There haven't been any changes.");
+		data.builder.push("**There haven't been any changes.**");
 	}
 
 	// Push link
@@ -133,7 +131,7 @@ function sortCommitList<T>(list: T[], transform: (obj: T) => Commit | undefined,
  * Sorts a commits list so that newest commits are on the bottom.
  * @param list The commit list.
  */
-export function sortCommitListReverse(list: Commit[]) {
+export function sortCommitListReverse(list: Commit[]): void {
 	list.sort((a, b) => {
 		const dateA = new Date(a.date);
 		const dateB = new Date(b.date);

--- a/tools/types/changelogTypes.ts
+++ b/tools/types/changelogTypes.ts
@@ -159,9 +159,14 @@ export interface Parser {
 	 * commit: The commit object.
 	 * commitMessage: The message of the commit.<p>
 	 * commitBody: The body of the commit. Might be undefined.<p>
-	 * return: True if parsing was successful, false if not.
+	 * return: True if parsing was successful, false if not. Can return Ignored if commit was ignored (not skipped).
 	 */
-	itemCallback: (parser: Parser, commit: Commit, commitMessage: string, commitBody?: string) => Promise<boolean>;
+	itemCallback: (
+		parser: Parser,
+		commit: Commit,
+		commitMessage: string,
+		commitBody?: string,
+	) => Promise<boolean | Ignored>;
 
 	/**
 	 * The callback to perform on any commits, which did not pass parsing. If not set, no callback will be performed, and those commits will be discarded.
@@ -197,6 +202,25 @@ export interface Parser {
 	 * return: True if to add, false if not.
 	 */
 	addCommitListCallback: (commit: Commit, parsed: boolean) => boolean;
+}
+
+export interface IgnoreInfo {
+	before?: string;
+	after?: string;
+	addCommitList?: boolean;
+}
+
+export class Ignored {
+	private readonly addCommitList: boolean | undefined;
+
+	constructor(addCommitList?: boolean) {
+		this.addCommitList = addCommitList;
+	}
+
+	getCommitList(): boolean {
+		if (this.addCommitList === undefined) return false;
+		return this.addCommitList;
+	}
 }
 
 export interface ModChangeInfo {

--- a/tools/util/util.ts
+++ b/tools/util/util.ts
@@ -256,6 +256,17 @@ export async function getChangelog(since = "HEAD", to = "HEAD", dirs: string[] =
 }
 
 /**
+ * Gets the list of tags that are at or before a certain ref point.
+ * @param ref The ref point. Can be a tag or a commit sha. If not set, defaults to HEAD.
+ * @returns tags An array of all the tags
+ */
+export async function getTags(ref = "HEAD"): Promise<string[]> {
+	const options: string[] = ["--merged", ref];
+	const test = await git.tags(options);
+	return test.all;
+}
+
+/**
  * Gets the file at a certain point in time.
  * @param path The path to the file
  * @param revision The git ref point. Can also be a commit SHA


### PR DESCRIPTION
Allows for commits to be ignored, following certain parameters (before and/or after).
Works in Expand Blocks.
Also has an extra option to allow the commit to stay in the commit list after ignore.

Ignore works:
- After the Fixup Stage
- After the default skip stage
- after the expand stage
Before all other stages