### PR TITLE
Add OAuth v1.06.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -659,6 +659,11 @@
       "required": true
     },
     {
+      "projectID": 513857,
+      "fileID": 3739783,
+      "required": true
+    },
+    {
       "projectID": 538092,
       "fileID": 3817892,
       "required": true

--- a/manifest.json
+++ b/manifest.json
@@ -661,7 +661,10 @@
     {
       "projectID": 513857,
       "fileID": 3739783,
-      "required": true
+      "required": true,
+      "sides": [
+        "client"
+      ]
     },
     {
       "projectID": 538092,


### PR DESCRIPTION
Fixes occasional invalid session issues by relogin.

Not using ReAuth as its 1.12 version does not support Microsoft Accounts.

Nomifactory has it.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/247.
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/76 (RAD is made obsolete by https://github.com/Nomi-CEu/Nomi-CEu/commit/878eb9bd9ab78158ea7350402c4da448cbdcc8af)