### PR TITLE
Add Some Emphasis to Addon Script Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Nomi-CEu comes with addon scripts for the following mods. You can drop them into
 - [Lazy AE2](https://www.curseforge.com/minecraft/mc-mods/lazy-ae2)  
 - [Project Red - Illumination](https://www.curseforge.com/minecraft/mc-mods/project-red-illumination)    
 
-\* Note: If you are adding these mods via the CurseForge app, remove the extra copy of AE2 (non-extended life), of which it might automatically download.
+\* Note: If you are adding these mods via the CurseForge app, remove the extra copy of AE2 **(*non*-extended life)**, of which it might automatically download.
 
 ## Expert Mode 
 If you want a harder, or perhaps a more "true" GregTech experience, check out the Expert mode. This pack mode is based on the [Self-Torture Edition Fork](https://github.com/NotMyWing/Omnifactory-Self-Torture-Edition) of the original pack. 


### PR DESCRIPTION
People deleted the actual ae2... when the error clearly said that a non-related dep was missing.