### PR TITLE
Update GT Drawers from v1.0.6 to v1.0.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -738,7 +738,7 @@
     },
     {
       "projectID": 845779,
-      "fileID": 4661741,
+      "fileID": 5006537,
       "required": true
     },
     {


### PR DESCRIPTION
This release changes the mod name, and removes the useless mod tooltip.