### PR TITLE
Fix QB Icon for Lossless Cables (509)

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -27183,9 +27183,9 @@
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
-            "Damage:2": 32012,
+            "Damage:2": 12,
             "OreDict:8": "",
-            "id:8": "gregtech:wire_octal"
+            "id:8": "nomilabs:wire_octal"
           },
           "ignoresview:1": 0,
           "ismain:1": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -27183,9 +27183,9 @@
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
-            "Damage:2": 32012,
+            "Damage:2": 12,
             "OreDict:8": "",
-            "id:8": "gregtech:wire_octal"
+            "id:8": "nomilabs:wire_octal"
           },
           "ignoresview:1": 0,
           "ismain:1": 1,


### PR DESCRIPTION
Before:
![image](https://github.com/Nomi-CEu/Nomi-CEu/assets/5544386/fafa9d4e-0d70-4ce0-b11f-609ce2199f30)

After:
![image](https://github.com/Nomi-CEu/Nomi-CEu/assets/5544386/d0cdb8f4-13c5-4e45-8889-68bc8e5e967b)

Checked on 1.7, it's 8x energetic alloy cable.