### PR TITLE
Tweak Universal Crystallizer Recieps

### DIFF
--- a/overrides/scripts/multiblocks_expert.zs
+++ b/overrides/scripts/multiblocks_expert.zs
@@ -1092,11 +1092,13 @@ naquadah_reactor_2.recipeBuilder()
 // Universal Crystallizer Recipes
 // recipes MUST have an eut below 1 UV amp (524,288 EU/t)
 // in order to run without using higher tier energy hatches
+
+// original was 3 ticks, 23592960 eut
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64)
     .outputs(<minecraft:diamond> * 32)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(150).EUt(471859).buildAndRegister();
 
 // Combination recipe is 4,000,000 RF for all empowered recipes
 // 4,000,000 RF -> 1,000,000 EU

--- a/overrides/scripts/multiblocks_expert.zs
+++ b/overrides/scripts/multiblocks_expert.zs
@@ -1142,16 +1142,22 @@ universal_crystallizer.recipeBuilder()
     .inputs(<actuallyadditions:block_crystal_empowered:4>, <metaitem:blockNetherStar> * 2, <draconicevolution:draconic_core> * 4, <armorplus:block_compressed_infused_lava_crystal> * 2)
     .outputs(<draconicevolution:wyvern_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(30).EUt(23592960).buildAndRegister();
+    .duration(30).EUt(1462867).buildAndRegister();
+    // DE recipe is 175,544,000 RF -> 43,886,000 EU total
+    // at 30 ticks, eu/t would be ~1,462,867 EU/t
 
 universal_crystallizer.recipeBuilder()
     .inputs(<minecraft:nether_star>, <draconicevolution:wyvern_core> * 4, <metaitem:nomilabs:blockAwakenedDraconium> * 2)
     .outputs(<draconicevolution:awakened_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(30).EUt(23592960).buildAndRegister();
+    .duration(240).EUt(1562500).buildAndRegister();
+    // DE recipe is 3,000,000,000 RF -> 750,000,000 EU total
+    // at 240 ticks, eu/t would be ~1,562,500 EU/t
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:blockDraconium> * 5, <draconicevolution:wyvern_core> * 4, <draconicevolution:dragon_heart> * 2)
     .outputs(<metaitem:nomilabs:blockAwakenedDraconium> * 5)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(30).EUt(23592960).buildAndRegister();
+    .duration(2160).EUt(2777778).buildAndRegister();
+    // DE recipe is 24,000,000,000 RF -> 6,000,000,000 EU total
+    // at 2160 ticks, eu/t would be ~2,777,778 EU/t

--- a/overrides/scripts/multiblocks_expert.zs
+++ b/overrides/scripts/multiblocks_expert.zs
@@ -1090,7 +1090,7 @@ naquadah_reactor_2.recipeBuilder()
     .buildAndRegister();
 
 // Universal Crystallizer Recipes
-// recipes MUST have an eut below 1 UV amp (524,288 EU/t)
+// recipes MUST have an eut below 1 UHV amp (2,097,152 EU/t)
 // in order to run without using higher tier energy hatches
 
 // original was 3 ticks, 23592960 eut
@@ -1098,74 +1098,73 @@ universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64)
     .outputs(<minecraft:diamond> * 32)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(150).EUt(471859).buildAndRegister();
+    .duration(60).EUt(1179648).buildAndRegister();
 
 // Combination recipe is 4,000,000 RF for all empowered recipes
 // 4,000,000 RF -> 1,000,000 EU
-// at 2 ticks the EU/t would be 500,000 EU/t
-// multiply ticks by 7 -> 14 ticks
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustIron> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:5> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustRedstone> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustLapis> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:1> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustCoal> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:3> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustDiamond> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:2> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustEmerald> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:4> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(14).EUt(500000).buildAndRegister();
+    .duration(7).EUt(1000000).buildAndRegister();
 
+// original was 3 ticks, 23592960 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:gemPerfectDiamond> * 3, <minecraft:nether_star> * 9, <ore:plateDiamond> * 27, <ore:gemDiamond> * 27)
     .outputs(<metaitem:nomilabs:ingotCrystalMatrix>)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(45).EUt(1572864).buildAndRegister();
 
 // DE recipe is 175,544,000 RF -> 43,886,000 EU total
-// at 100 ticks, eu/t would be 438,860 EU/t
+// at 25 ticks, eu/t would be 1,755,440 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<actuallyadditions:block_crystal_empowered:4>, <metaitem:blockNetherStar> * 2, <draconicevolution:draconic_core> * 4, <armorplus:block_compressed_infused_lava_crystal> * 2)
     .outputs(<draconicevolution:wyvern_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(100).EUt(438860).buildAndRegister();
+    .duration(25).EUt(1755440).buildAndRegister();
 
 // DE recipe is 3,000,000,000 RF -> 750,000,000 EU total
-// at 1500 ticks, eu/t would be 500,000 EU/t
+// at 375 ticks, eu/t would be 2,000,000 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<minecraft:nether_star>, <draconicevolution:wyvern_core> * 4, <metaitem:nomilabs:blockAwakenedDraconium> * 2)
     .outputs(<draconicevolution:awakened_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(1500).EUt(500000).buildAndRegister();
+    .duration(375).EUt(2000000).buildAndRegister();
 
 // DE recipe is 24,000,000,000 RF -> 6,000,000,000 EU total
-// at 12,000 ticks, eu/t would be 500,000 EU/t
+// at 3,000 ticks, eu/t would be 2,000,000 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:blockDraconium> * 5, <draconicevolution:wyvern_core> * 4, <draconicevolution:dragon_heart> * 2)
     .outputs(<metaitem:nomilabs:blockAwakenedDraconium> * 5)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(12000).EUt(500000).buildAndRegister();
+    .duration(3000).EUt(2000000).buildAndRegister();

--- a/overrides/scripts/multiblocks_expert.zs
+++ b/overrides/scripts/multiblocks_expert.zs
@@ -1098,41 +1098,45 @@ universal_crystallizer.recipeBuilder()
     .fluidInputs(<liquid:naquadah_enriched> * 3)
     .duration(3).EUt(23592960).buildAndRegister();
 
+// Combination recipe is 4,000,000 RF for all empowered recipes
+// 4,000,000 RF -> 1,000,000 EU
+// at 2 ticks the EU/t would be 500,000 EU/t
+// multiply ticks by 7 -> 14 ticks
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustIron> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:5> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustRedstone> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustLapis> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:1> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustCoal> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:3> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustDiamond> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:2> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustEmerald> * 63)
     .outputs(<actuallyadditions:block_crystal_empowered:4> * 7)
     .fluidInputs(<liquid:naquadah_enriched> * 3)
-    .duration(3).EUt(23592960).buildAndRegister();
+    .duration(14).EUt(500000).buildAndRegister();
 
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:gemPerfectDiamond> * 3, <minecraft:nether_star> * 9, <ore:plateDiamond> * 27, <ore:gemDiamond> * 27)
@@ -1154,7 +1158,7 @@ universal_crystallizer.recipeBuilder()
     .inputs(<minecraft:nether_star>, <draconicevolution:wyvern_core> * 4, <metaitem:nomilabs:blockAwakenedDraconium> * 2)
     .outputs(<draconicevolution:awakened_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(1500).EUt(1562500).buildAndRegister();
+    .duration(1500).EUt(500000).buildAndRegister();
 
 // DE recipe is 24,000,000,000 RF -> 6,000,000,000 EU total
 // at 12,000 ticks, eu/t would be 500,000 EU/t

--- a/overrides/scripts/multiblocks_expert.zs
+++ b/overrides/scripts/multiblocks_expert.zs
@@ -1090,6 +1090,8 @@ naquadah_reactor_2.recipeBuilder()
     .buildAndRegister();
 
 // Universal Crystallizer Recipes
+// recipes MUST have an eut below 1 UV amp (524,288 EU/t)
+// in order to run without using higher tier energy hatches
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64, <ore:dustCarbon> * 64)
     .outputs(<minecraft:diamond> * 32)
@@ -1138,26 +1140,26 @@ universal_crystallizer.recipeBuilder()
     .fluidInputs(<liquid:naquadah_enriched> * 3)
     .duration(3).EUt(23592960).buildAndRegister();
 
+// DE recipe is 175,544,000 RF -> 43,886,000 EU total
+// at 100 ticks, eu/t would be 438,860 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<actuallyadditions:block_crystal_empowered:4>, <metaitem:blockNetherStar> * 2, <draconicevolution:draconic_core> * 4, <armorplus:block_compressed_infused_lava_crystal> * 2)
     .outputs(<draconicevolution:wyvern_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(30).EUt(1462867).buildAndRegister();
-    // DE recipe is 175,544,000 RF -> 43,886,000 EU total
-    // at 30 ticks, eu/t would be ~1,462,867 EU/t
+    .duration(100).EUt(438860).buildAndRegister();
 
+// DE recipe is 3,000,000,000 RF -> 750,000,000 EU total
+// at 1500 ticks, eu/t would be 500,000 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<minecraft:nether_star>, <draconicevolution:wyvern_core> * 4, <metaitem:nomilabs:blockAwakenedDraconium> * 2)
     .outputs(<draconicevolution:awakened_core>)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(240).EUt(1562500).buildAndRegister();
-    // DE recipe is 3,000,000,000 RF -> 750,000,000 EU total
-    // at 240 ticks, eu/t would be ~1,562,500 EU/t
+    .duration(1500).EUt(1562500).buildAndRegister();
 
+// DE recipe is 24,000,000,000 RF -> 6,000,000,000 EU total
+// at 12,000 ticks, eu/t would be 500,000 EU/t
 universal_crystallizer.recipeBuilder()
     .inputs(<ore:blockDraconium> * 5, <draconicevolution:wyvern_core> * 4, <draconicevolution:dragon_heart> * 2)
     .outputs(<metaitem:nomilabs:blockAwakenedDraconium> * 5)
     .fluidInputs(<liquid:naquadah_enriched> * 30)
-    .duration(2160).EUt(2777778).buildAndRegister();
-    // DE recipe is 24,000,000,000 RF -> 6,000,000,000 EU total
-    // at 2160 ticks, eu/t would be ~2,777,778 EU/t
+    .duration(12000).EUt(500000).buildAndRegister();


### PR DESCRIPTION
The recipes Eu/t been tweaked to be below 1 amp of UHV (2,097,152 EU/t). Eu/t and durations have also been balanced to make the EU total match the RF totals of DE fusion and combination crafting recipes,