### PR TITLE
Improve Changelog Tags

### DIFF
--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,21 +1,20 @@
 {
-	"name": "nomifactory-buildtools",
+	"name": "nomi-ceu-build-tools",
 	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "nomifactory-buildtools",
+			"name": "nomi-ceu-build-tools",
 			"version": "1.2.2",
 			"license": "LGPL-3.0",
 			"dependencies": {
 				"@actions/core": "^1.10.1",
 				"@egjs/list-differ": "^1.0.1",
-				"@iarna/toml": "^2.2.5",
-				"@types/iarna__toml": "^2.0.5",
 				"@types/json-stable-stringify-without-jsonify": "^1.0.1",
 				"dedent-js": "^1.0.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1"
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"toml-v1": "^1.0.0"
 			},
 			"devDependencies": {
 				"@octokit/rest": "^18.3.5",
@@ -264,11 +263,6 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
-		},
-		"node_modules/@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.0",
@@ -599,14 +593,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/iarna__toml": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
-			"integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/imagemin": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@types/imagemin/-/imagemin-8.0.0.tgz",
@@ -694,7 +680,8 @@
 		"node_modules/@types/node": {
 			"version": "18.11.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+			"dev": true
 		},
 		"node_modules/@types/q": {
 			"version": "1.5.5",
@@ -1037,7 +1024,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3520,8 +3506,7 @@
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
@@ -6673,7 +6658,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10361,7 +10345,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -10405,7 +10388,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -10521,6 +10503,14 @@
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"dev": true,
 			"optional": true
+		},
+		"node_modules/super-sources": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/super-sources/-/super-sources-1.1.1.tgz",
+			"integrity": "sha512-urkv0ksWoPIdRQjiDRrMLLLZvZtsJqU6Txlh3cxi/NhpC+NzlC170owSe8ruOZRJN1eWZ+GdvNsh/QXqMizxtQ==",
+			"dependencies": {
+				"string-width": "^4.2.3"
+			}
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -10916,6 +10906,14 @@
 			"dependencies": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
+			}
+		},
+		"node_modules/toml-v1": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toml-v1/-/toml-v1-1.0.0.tgz",
+			"integrity": "sha512-fMk7vzBrPNFeuAvpN1eLeC3QBvTAKmqD3XRvHj5Z2nGasQfF+b//S4OqByUYRGASwshXM2TBCmMXMNWbnm7EYA==",
+			"dependencies": {
+				"super-sources": "^1.1.1"
 			}
 		},
 		"node_modules/tough-cookie": {
@@ -12038,11 +12036,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
-		},
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -12349,14 +12342,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/iarna__toml": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
-			"integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/imagemin": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@types/imagemin/-/imagemin-8.0.0.tgz",
@@ -12444,7 +12429,8 @@
 		"@types/node": {
 			"version": "18.11.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+			"dev": true
 		},
 		"@types/q": {
 			"version": "1.5.5",
@@ -12688,8 +12674,7 @@
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
@@ -14681,8 +14666,7 @@
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -17150,8 +17134,7 @@
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"is-gif": {
 			"version": "3.0.0",
@@ -20012,7 +19995,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -20047,7 +20029,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -20132,6 +20113,14 @@
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"dev": true,
 			"optional": true
+		},
+		"super-sources": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/super-sources/-/super-sources-1.1.1.tgz",
+			"integrity": "sha512-urkv0ksWoPIdRQjiDRrMLLLZvZtsJqU6Txlh3cxi/NhpC+NzlC170owSe8ruOZRJN1eWZ+GdvNsh/QXqMizxtQ==",
+			"requires": {
+				"string-width": "^4.2.3"
+			}
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -20468,6 +20457,14 @@
 						"xtend": "~4.0.1"
 					}
 				}
+			}
+		},
+		"toml-v1": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toml-v1/-/toml-v1-1.0.0.tgz",
+			"integrity": "sha512-fMk7vzBrPNFeuAvpN1eLeC3QBvTAKmqD3XRvHj5Z2nGasQfF+b//S4OqByUYRGASwshXM2TBCmMXMNWbnm7EYA==",
+			"requires": {
+				"super-sources": "^1.1.1"
 			}
 		},
 		"tough-cookie": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "nomifactory-buildtools",
+	"name": "nomi-ceu-build-tools",
 	"version": "1.2.2",
-	"description": "Nomifactory Server Builder.",
+	"description": "Nomifactory CEu Buildscript and Tools.",
 	"main": "gulpfile.js",
-	"author": "NotMyWing",
+	"author": "Nomi-CEu Team",
 	"license": "LGPL-3.0",
 	"devDependencies": {
 		"@octokit/rest": "^18.3.5",
@@ -52,10 +52,9 @@
 	"dependencies": {
 		"@actions/core": "^1.10.1",
 		"@egjs/list-differ": "^1.0.1",
-		"@iarna/toml": "^2.2.5",
-		"@types/iarna__toml": "^2.0.5",
 		"@types/json-stable-stringify-without-jsonify": "^1.0.1",
 		"dedent-js": "^1.0.1",
-		"json-stable-stringify-without-jsonify": "^1.0.1"
+		"json-stable-stringify-without-jsonify": "^1.0.1",
+		"toml-v1": "^1.0.0"
 	}
 }

--- a/tools/tasks/changelog/changelogData.ts
+++ b/tools/tasks/changelog/changelogData.ts
@@ -83,14 +83,15 @@ export default class ChangelogData {
 	/**
 	 * Setups the state for a iteration. Init must be called first.
 	 */
-	setupIteration(compareTag: string): void {
+	async setupIteration(compareTag: string): Promise<void> {
 		this.since = compareTag;
+		this.compareTags = new Set<string>(await getTags(this.since));
 	}
 
 	/**
 	 * Resets the state for a future iteration. Init must be called first.
 	 */
-	async resetForIteration(): Promise<void> {
+	resetForIteration(): void {
 		// Reset all lists, except builder
 		this.commitList = [];
 
@@ -101,8 +102,6 @@ export default class ChangelogData {
 		this.modInfoList = new Map<number, ParsedModInfo>();
 
 		// Tags list is fine because the 'to' (Target) stays the same
-
-		// Regenerate 'since' (Compare) tags list
-		this.compareTags = new Set<string>(await getTags(this.since));
+		// Other Tags list is generated at setup
 	}
 }

--- a/tools/tasks/changelog/changelogData.ts
+++ b/tools/tasks/changelog/changelogData.ts
@@ -16,8 +16,11 @@ export default class ChangelogData {
 	// Map of a commit SHA to the commits which need to be added to its commit list.
 	combineList: Map<string, Commit[]>;
 
-	// Set of tags
+	// Set of tags before 'to' (Target)
 	tags: Set<string>;
+
+	// Set of tags before 'since' (Compare)
+	compareTags: Set<string>;
 
 	// Map of project IDs to info text and/or details
 	modInfoList: Map<number, ParsedModInfo>;
@@ -59,6 +62,7 @@ export default class ChangelogData {
 		this.combineList = new Map<string, Commit[]>();
 
 		this.tags = new Set<string>(await getTags(this.to));
+		this.compareTags = new Set<string>(await getTags(this.since));
 
 		this.modInfoList = new Map<number, ParsedModInfo>();
 	}
@@ -86,7 +90,7 @@ export default class ChangelogData {
 	/**
 	 * Resets the state for a future iteration. Init must be called first.
 	 */
-	resetForIteration(): void {
+	async resetForIteration(): Promise<void> {
 		// Reset all lists, except builder
 		this.commitList = [];
 
@@ -96,6 +100,9 @@ export default class ChangelogData {
 
 		this.modInfoList = new Map<number, ParsedModInfo>();
 
-		// Tags list is fine because the `to` stays the same
+		// Tags list is fine because the 'to' (Target) stays the same
+
+		// Regenerate 'since' (Compare) tags list
+		this.compareTags = new Set<string>(await getTags(this.since));
 	}
 }

--- a/tools/tasks/changelog/createChangelog.ts
+++ b/tools/tasks/changelog/createChangelog.ts
@@ -41,7 +41,7 @@ async function createChangelog(): Promise<ChangelogData> {
 			if (iteration < tags.length - 1) {
 				// More to go
 				pushSeperator(data);
-				data.resetForIteration();
+				await data.resetForIteration();
 			}
 		}
 		return data;

--- a/tools/tasks/changelog/createChangelog.ts
+++ b/tools/tasks/changelog/createChangelog.ts
@@ -27,7 +27,7 @@ async function createChangelog(): Promise<ChangelogData> {
 		for (const tag of tags) {
 			const iteration = tags.indexOf(tag);
 			log(`Iteration ${iteration + 1} of Changelog.`);
-			data.setupIteration(tag);
+			await data.setupIteration(tag);
 			categoriesSetup();
 			specialParserSetup(data);
 
@@ -41,7 +41,7 @@ async function createChangelog(): Promise<ChangelogData> {
 			if (iteration < tags.length - 1) {
 				// More to go
 				pushSeperator(data);
-				await data.resetForIteration();
+				data.resetForIteration();
 			}
 		}
 		return data;

--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -31,6 +31,7 @@ export const fixUpList = "fixes";
 export const ignoreKey = "[IGNORE]";
 export const modInfoKey = "[MOD INFO]";
 export const modInfoList = "infos";
+export const priorityKey = "[PRIORITY]";
 
 /* Sub Category Keys */
 // Mode Category Keys

--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -228,8 +228,10 @@ export const modChangesAllocations: Record<ModChangesType, ModChangesAllocation>
 // Ignore Allocations
 
 /* Ignore Checks */
-const beforeCheck: IgnoreCheck = (tag, data) => !data.tags.has(tag);
-const afterCheck: IgnoreCheck = (tag, data) => data.tags.has(tag);
+const targetBeforeCheck: IgnoreCheck = (tag, data) => !data.tags.has(tag);
+const targetAfterCheck: IgnoreCheck = (tag, data) => data.tags.has(tag);
+const compareBeforeCheck: IgnoreCheck = (tag, data) => !data.compareTags.has(tag);
+const compareAfterCheck: IgnoreCheck = (tag, data) => data.compareTags.has(tag);
 const compareIsCheck: IgnoreCheck = (tag, data) => data.since === tag;
 const compareNotCheck: IgnoreCheck = (tag, data) => data.since !== tag;
 const targetIsCheck: IgnoreCheck = (tag, data) => data.to === tag;
@@ -237,8 +239,10 @@ const targetNotCheck: IgnoreCheck = (tag, data) => data.to !== tag;
 
 /* Ignore Checks Map */
 export const ignoreChecks: Record<string, IgnoreCheck> = {
-	before: beforeCheck,
-	after: afterCheck,
+	targetBefore: targetBeforeCheck,
+	targetAfter: targetAfterCheck,
+	compareBefore: compareBeforeCheck,
+	compareAfter: compareAfterCheck,
 	compareIs: compareIsCheck,
 	compareNot: compareNotCheck,
 	targetIs: targetIsCheck,

--- a/tools/tasks/changelog/parser.ts
+++ b/tools/tasks/changelog/parser.ts
@@ -21,8 +21,17 @@ export default async function parseParser(data: ChangelogData, parser: Parser): 
 
 		if (data.commitFixes.has(commit.hash)) {
 			const fixUpInfo = data.commitFixes.get(commit.hash);
-			commit.message = fixUpInfo.newTitle;
-			commit.body = fixUpInfo.newBody;
+			if (fixUpInfo.newTitle) commit.message = fixUpInfo.newTitle;
+			if (fixUpInfo.newBody) {
+				switch (fixUpInfo.mode) {
+					case "REPLACE":
+						commit.body = fixUpInfo.newBody;
+						break;
+					case "ADDITION":
+						commit.body = commit.body.concat(`\n\n${fixUpInfo.newBody}`);
+						break;
+				}
+			}
 		}
 
 		if (parser.skipCallback(commit, commit.message, commit.body)) {

--- a/tools/tasks/changelog/parser.ts
+++ b/tools/tasks/changelog/parser.ts
@@ -8,8 +8,9 @@ import {
 	ignoreKey,
 	modInfoKey,
 	noCategoryKey,
+	priorityKey,
 } from "./definitions";
-import { parseCombine, parseDetails, parseExpand, parseIgnore, parseModInfo } from "./specialParser";
+import { parseCombine, parseDetails, parseExpand, parseIgnore, parseModInfo, parsePriority } from "./specialParser";
 import { getChangelog } from "../../util/util";
 import ChangelogData from "./changelogData";
 
@@ -78,6 +79,20 @@ export async function parseCommitBody(
 		// Only return if ignore is not undefined
 		if (ignore) return ignore;
 	}
+
+	let newPriority = 0;
+	if (commitBody.includes(priorityKey)) {
+		const priority = await parsePriority(commitBody, commitObject);
+
+		// Only set if priority is not undefined or 0
+		if (priority) newPriority = priority;
+	}
+	// Copy commit if new priority (don't mess it up for other changelog messages when using expand)
+	if (commitObject.priority !== newPriority) {
+		commitObject = { ...commitObject };
+		commitObject.priority = newPriority;
+	}
+
 	if (commitBody.includes(modInfoKey)) await parseModInfo(commitBody, commitObject);
 	if (commitBody.includes(detailsKey)) {
 		await parseDetails(commitMessage, commitBody, commitObject, parser);

--- a/tools/tasks/changelog/pusher.ts
+++ b/tools/tasks/changelog/pusher.ts
@@ -146,6 +146,8 @@ function sortCommitList<T>(list: T[], transform: (obj: T) => Commit | undefined,
 		const dateA = new Date(commitA.date);
 		const dateB = new Date(commitB.date);
 
+		// This is reversed, so higher priorities go on top
+		if (commitB.priority !== commitA.priority) return commitB.priority - commitA.priority;
 		// This is reversed, so the newest commits go on top
 		if (dateB.getTime() - dateA.getTime() !== 0) return dateB.getTime() - dateA.getTime();
 		if (backup) return backup(a, b);
@@ -162,7 +164,9 @@ export function sortCommitListReverse(list: Commit[]): void {
 		const dateA = new Date(a.date);
 		const dateB = new Date(b.date);
 
-		if (dateB.getTime() - dateA.getTime() !== 0) return dateA.getTime() - dateB.getTime();
+		// This is reversed, so higher priorities go on top
+		if (b.priority !== a.priority) return b.priority - a.priority; // Priority is still highest first
+		if (dateA.getTime() - dateB.getTime() !== 0) return dateA.getTime() - dateB.getTime();
 		return a.message.localeCompare(b.message);
 	});
 }

--- a/tools/types/changelogTypes.ts
+++ b/tools/types/changelogTypes.ts
@@ -256,8 +256,9 @@ export interface ExpandedMessage {
 
 export interface FixUpInfo {
 	sha: string;
-	newTitle: string;
+	newTitle?: string;
 	newBody?: string;
+	mode: FixUpMode;
 }
 
 export interface ModInfo {
@@ -271,6 +272,8 @@ export interface ParsedModInfo {
 	info?: string;
 	details?: ChangelogMessage[];
 }
+
+export type FixUpMode = "REPLACE" | "ADDITION";
 
 export type InputReleaseType = "Release" | "Beta Release" | "Alpha Release" | "Cutting Edge Build";
 

--- a/tools/types/changelogTypes.ts
+++ b/tools/types/changelogTypes.ts
@@ -8,6 +8,7 @@ export interface Commit {
 	body: string;
 	author_name: string;
 	author_email: string;
+	priority?: number;
 }
 
 /**
@@ -271,6 +272,10 @@ export interface ModInfo {
 export interface ParsedModInfo {
 	info?: string;
 	details?: ChangelogMessage[];
+}
+
+export interface PriorityInfo {
+	priority: number;
 }
 
 export type FixUpMode = "REPLACE" | "ADDITION";


### PR DESCRIPTION
Improves Fixup, Expand, Detail and Ignore Tags.

Adds Priority Tag.

Fixup Example: (You can now exclude `newTitle`, and just add to commit bodies)
```toml
[FIXUP]
sha = "dfa6d701175dea4440e7f8af4615d25aa578220a"
newBody = "[NM]"
mode = "ADDITION" # Can be REPLACE or ADDITION
[FIXUP]
```

If mode is excluded, default is replace, to allow for parity with legacy commits.

Expand Example: (You can now exclude `messageTitle`)
```toml
[EXPAND]
[[messages]]
messageBody = "[QB]"

[[messages]]
messageBody = '''
[DETAILS]
details = ["hi", ["bye"], "hi"]
[DETAILS]
[BUG]
'''
[EXPAND]
```

Details Example: (Improved way of defining nested details)

```toml
[DETAILS]
details = [
  "Hi",
  ["Bye", "Tomorrow",
    ["Nope"],
  "Hi Again"],
  "Bye"]
[DETAILS]

[BUG]
```

Before you would have to do:
```toml
[DETAILS]
details = [
  "Hi",
  """
    [DETAILS]
    details = [
      \"Bye\",
      \"Tomorrow\",
      \"\"\"
        [DETAILS]
        detail = "Nope"
        [DETAILS]
      \"\"\",
      \"Hi Again\",
    ]
    [DETAILS]
  """,
  "Bye",
]
[DETAILS]

[BUG]
```

The Old Version is still supported.

Priority Example:
```toml
[EXPAND]
[[messages]]
messageTitle = "a"
messageBody = '''
[BREAKING]
[DETAILS]
detail = "a (priority 1)"
[DETAILS]
[PRIORITY]
priority = 1
[PRIORITY]
'''

[[messages]]
messageBody = '''
[BREAKING]
[DETAILS]
detail = "aa (priority 2)"
[DETAILS]
[PRIORITY]
priority = 2
[PRIORITY]
'''
[EXPAND]
```

Higher Priorities go higher up than lower priorities.
Priorities are sorted first, before commit dates and by message title.

Final: More Ignore Options