### PR TITLE
Disable Vanilla Ores & Slightly Reduce HM Ore Gen

### DIFF
--- a/overrides/config-overrides/expert/gregtech/gregtech.cfg
+++ b/overrides/config-overrides/expert/gregtech/gregtech.cfg
@@ -753,7 +753,7 @@ general {
 
         # Specifies an additional random number of veins in a section.
         # Default: 0
-        I:additionalVeinsInSection=3
+        I:additionalVeinsInSection=2
 
         # Should all Stone Types drop unique Ore Item Blocks?
         # Default: false (meaning only Stone, Netherrack, and Endstone
@@ -765,7 +765,7 @@ general {
 
         # Whether to disable Vanilla ore generation in world.
         # Default: true
-        B:disableVanillaOres=false
+        B:disableVanillaOres=true
 
         # Whether veins should be generated in the center of chunks.
         # Default: true

--- a/overrides/config-overrides/normal/gregtech/gregtech.cfg
+++ b/overrides/config-overrides/normal/gregtech/gregtech.cfg
@@ -765,7 +765,7 @@ general {
 
         # Whether to disable Vanilla ore generation in world.
         # Default: true
-        B:disableVanillaOres=false
+        B:disableVanillaOres=true
 
         # Whether veins should be generated in the center of chunks.
         # Default: true

--- a/overrides/config/gregtech/gregtech.cfg
+++ b/overrides/config/gregtech/gregtech.cfg
@@ -765,7 +765,7 @@ general {
 
         # Whether to disable Vanilla ore generation in world.
         # Default: true
-        B:disableVanillaOres=false
+        B:disableVanillaOres=true
 
         # Whether veins should be generated in the center of chunks.
         # Default: true


### PR DESCRIPTION
Disables Vanilla Ores (Don't know why they were enabled)

Slightly reduces HM ore gen, now more consistent. 