### PR TITLE
Update Nomi-Labs from v0.6.20 to v0.6.21

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -763,7 +763,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5194128,
+      "fileID": 5212620,
       "required": true
     },
     {

--- a/overrides/config/EffortlessBuilding.cfg
+++ b/overrides/config/EffortlessBuilding.cfg
@@ -8,21 +8,21 @@ reach {
 
     # Maximum reach in creative
     # Keep in mind that chunks need to be loaded to be able to place blocks inside.
-    I:maxReachCreative=211
+    I:maxReachCreative=256
 
     # Maximum reach in survival without upgrades
     # Reach upgrades are craftable consumables that permanently increase reach.
     # Set to 0 to disable Effortless Building until the player has consumed a reach upgrade.
-    I:maxReachLevel0=24
+    I:maxReachLevel0=32
 
     # Maximum reach in survival with one upgrade
-    I:maxReachLevel1=51
+    I:maxReachLevel1=64
 
     # Maximum reach in survival with two upgrades
-    I:maxReachLevel2=104
+    I:maxReachLevel2=128
 
     # Maximum reach in survival with three upgrades
-    I:maxReachLevel3=211
+    I:maxReachLevel3=256
 }
 
 

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -14,11 +14,6 @@ advanced {
     # [default: false]
     B:allowOtherPackModes=false
 
-    # Whether to disable Advancements.
-    # Increases Load Speed, and reduces log errors.
-    # [default: false]
-    B:disableAdvancements=false
-
     # Whether to disable the Narrator.
     # Fixes Crashes in Arm Macs, in some very specific environments.
     # If your game is crashing, try enabling this!
@@ -217,7 +212,7 @@ content {
     # [default: true]
     B:enableAdvancedRocketryIntegration=true
 
-    # Whether to enable ArchitectureCraft Integration, which adds new slope variants.
+    # Whether to enable ArchitectureCraft Integration, which adds new slope variants, and improves the GUI of the Sawbench.
     # [default: true]
     B:enableArchitectureCraftIntegration=true
 
@@ -268,9 +263,64 @@ content {
         # Modifying Energy Core Structure with improvements, such as allowing blocks surrounding the structure.
         # Adding a destructor to the energy core.
         # Allow changing the speed of the builder.
+        # Allow disabling Fusion Recipes for Chaotic Upgrades, which are empty as none of the tools support it.
         # If this option is disabled, then energy cores made whilst this was enabled may break!
+        # None of the below options work if this config is set to false.
         # [default: true]
         B:enableDraconicEvolutionIntegration=true
+    }
+
+    ##########################################################################################################
+    # effortless building integration
+    #--------------------------------------------------------------------------------------------------------#
+    # Effortless Building Integration Settings
+    ##########################################################################################################
+
+    "effortless building integration" {
+        # Max Reach Per Axis Without Upgrades.
+        # [default: 8]
+        I:axisReach0=8
+
+        # Max Reach Per Axis With 1 Upgrade.
+        # [default: 16]
+        I:axisReach1=16
+
+        # Max Reach Per Axis With 2 Upgrades.
+        # [default: 32]
+        I:axisReach2=32
+
+        # Max Reach Per Axis With 3 Upgrades.
+        # [default: 64]
+        I:axisReach3=64
+
+        # Max Reach Per Axis In Creative.
+        # [default: 2048]
+        I:axisReachCreative=2048
+
+        # Max Blocks Placed at Once Without Upgrades.
+        # [default: 256]
+        I:blocksPlaced0=256
+
+        # Max Blocks Placed at Once With 1 Upgrade.
+        # [default: 2048]
+        I:blocksPlaced1=2048
+
+        # Max Blocks Placed at Once With 2 Upgrades.
+        # [default: 16384]
+        I:blocksPlaced2=16384
+
+        # Max Blocks Placed at Once With 3 Upgrades.
+        # [default: 131072]
+        I:blocksPlaced3=131072
+
+        # Max Blocks Placed at Once In Creative.
+        # [default: 1048576]
+        I:blocksPlacedCreative=1048576
+
+        # Whether to enable Effortless Building Integration, which splits the parts of reach.
+        # None of the below options work if this config is set to false.
+        # [default: true]
+        B:enableEffortlessBuildingIntegration=true
     }
 
 }


### PR DESCRIPTION
Can now separately change all aspects of range.

Changes the default range distance to powers of 2.

Also fixes Mode-Only Multiblock Structures showing up in the other mode.