### PR TITLE
Allow Fixes to Not Replace the Target Commit's Fixes

### DIFF
--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -1,4 +1,13 @@
-import { Category, Commit, IgnoreCheck, Ignored, IgnoreLogic, Parser, SubCategory } from "../../types/changelogTypes";
+import {
+	Category,
+	Commit,
+	FixUpInfo,
+	IgnoreCheck,
+	Ignored,
+	IgnoreLogic,
+	Parser,
+	SubCategory
+} from "../../types/changelogTypes";
 import { modpackManifest } from "../../globals";
 import { parseCommitBody } from "./parser";
 import { parseFixUp } from "./specialParser";
@@ -137,9 +146,12 @@ const defaultParsingCallback = async (
 const fixupParsing: Parser = {
 	skipCallback: () => false,
 	// No need to care about message/body, never parse expand/details commits
-	itemCallback: (_parser, commit) => parseFixUp(commit),
+	itemCallback: (_parser, commit, _commitMessage: string, _commitBody?: string, fix?: FixUpInfo) =>
+		parseFixUp(commit, fix),
 	addCommitListCallback: () => false,
 	addSHACallback: () => false,
+	// Don't apply fixup if it is not meant to apply to fixes
+	applyFixCalback: (fix) => fix.changeFixes === undefined || fix.changeFixes === null || (fix.changeFixes as boolean),
 };
 
 const overridesParsing: Parser = {

--- a/tools/tasks/changelog/parser.ts
+++ b/tools/tasks/changelog/parser.ts
@@ -1,4 +1,4 @@
-import { Category, Commit, Ignored, Parser, SubCategory } from "../../types/changelogTypes";
+import { Category, Commit, FixUpInfo, Ignored, Parser, SubCategory } from "../../types/changelogTypes";
 import {
 	categories,
 	combineKey,
@@ -20,18 +20,19 @@ export default async function parseParser(data: ChangelogData, parser: Parser): 
 	for (const commit of commits) {
 		if (data.shaList.has(commit.hash)) continue;
 
+		let savedFix: FixUpInfo = undefined;
+		console.log(`Parsing Commit ${commit.hash} with Parser ${parser.dirs}`)
+		console.log(Array.from(data.commitFixes.values()))
 		if (data.commitFixes.has(commit.hash)) {
 			const fixUpInfo = data.commitFixes.get(commit.hash);
-			if (fixUpInfo.newTitle) commit.message = fixUpInfo.newTitle;
-			if (fixUpInfo.newBody) {
-				switch (fixUpInfo.mode) {
-					case "REPLACE":
-						commit.body = fixUpInfo.newBody;
-						break;
-					case "ADDITION":
-						commit.body = commit.body.concat(`\n\n${fixUpInfo.newBody}`);
-						break;
-				}
+			if (!parser.applyFixCalback || parser.applyFixCalback(fixUpInfo)) {
+				applyFix(commit, fixUpInfo);
+				console.log("Applying Fix");
+				console.log(fixUpInfo);
+			} else {
+				savedFix = fixUpInfo;
+				console.log("Saving Fix");
+				console.log(fixUpInfo);
 			}
 		}
 
@@ -40,7 +41,7 @@ export default async function parseParser(data: ChangelogData, parser: Parser): 
 			continue;
 		}
 
-		const parsed = await parser.itemCallback(parser, commit, commit.message, commit.body);
+		const parsed = await parser.itemCallback(parser, commit, commit.message, commit.body, savedFix);
 		if (parsed instanceof Ignored) {
 			if (parsed.getCommitList() && parser.addCommitListCallback) {
 				if (parser.addCommitListCallback(commit, true)) data.commitList.push(commit);
@@ -52,6 +53,20 @@ export default async function parseParser(data: ChangelogData, parser: Parser): 
 		if (!parser.addSHACallback || parser.addSHACallback(commit, parsed)) data.shaList.add(commit.hash);
 
 		if (parser.addCommitListCallback(commit, parsed)) data.commitList.push(commit);
+	}
+}
+
+function applyFix(commit: Commit, fix: FixUpInfo) {
+	if (fix.newTitle) commit.message = fix.newTitle;
+	if (fix.newBody) {
+		switch (fix.mode) {
+			case "REPLACE":
+				commit.body = fix.newBody;
+				break;
+			case "ADDITION":
+				commit.body = commit.body.concat(`\n\n${fix.newBody}`);
+				break;
+		}
 	}
 }
 

--- a/tools/tasks/changelog/specialParser.ts
+++ b/tools/tasks/changelog/specialParser.ts
@@ -152,8 +152,9 @@ export async function parseIgnore(commitBody: string, commitObject: Commit): Pro
 /**
  * Parses a commit with 'Fixup'.
  */
-export async function parseFixUp(commit: Commit): Promise<boolean> {
+export async function parseFixUp(commit: Commit, fix?: FixUpInfo): Promise<boolean> {
 	if (!commit.body || !commit.body.includes(fixUpKey)) return false;
+	console.log(commit.hash, Array.from(data.commitFixes.values()), fix)
 	await parseTOMLWithRootToList<FixUpInfo>(
 		commit.body,
 		commit,
@@ -167,13 +168,31 @@ export async function parseFixUp(commit: Commit): Promise<boolean> {
 		},
 		(item) => item as unknown as FixUpInfo,
 		(matter) => {
+			let title = commit.message;
+			// Replace "\r\n" (Caused by editing on GitHub) with "\n", as the output matter has this done.
+			let body = commit.body.replace(/\r\n/g, "\n").replace(matter.matter.trim(), "");
+
+			// Apply Ignored Fixes
+			if (fix) {
+				if (fix.newTitle) title = fix.newTitle;
+				if (fix.newBody) {
+					switch (fix.mode) {
+						case "REPLACE":
+							body = fix.newBody;
+							break;
+						case "ADDITION":
+							body = body.concat(`\n\n${fix.newBody}`);
+							break;
+					}
+				}
+			}
+
 			// Must override, even if newer commits specified changes, as need to remove fixup data
 			data.commitFixes.set(commit.hash, {
 				sha: commit.hash,
 				mode: "REPLACE",
-				newTitle: commit.message,
-				// Replace "\r\n" (Caused by editing on GitHub) with "\n", as the output matter has this done.
-				newBody: commit.body.replace(/\r\n/g, "\n").replace(matter.matter.trim(), ""),
+				newTitle: title,
+				newBody: body,
 			});
 		},
 	);

--- a/tools/types/changelogTypes.ts
+++ b/tools/types/changelogTypes.ts
@@ -166,6 +166,7 @@ export interface Parser {
 	 * commit: The commit object.
 	 * commitMessage: The message of the commit.<p>
 	 * commitBody: The body of the commit. Might be undefined.<p>
+	 * fix: The fix, if it is not already applied. Usually undefined. Always undefined if applyFixCallback is unset.<p>
 	 * return: True if parsing was successful, false if not. Can return Ignored if commit was ignored (not skipped).
 	 */
 	itemCallback: (
@@ -173,6 +174,7 @@ export interface Parser {
 		commit: Commit,
 		commitMessage: string,
 		commitBody?: string,
+		fix?: FixUpInfo,
 	) => Promise<boolean | Ignored>;
 
 	/**
@@ -209,6 +211,15 @@ export interface Parser {
 	 * return: True if to add, false if not.
 	 */
 	addCommitListCallback: (commit: Commit, parsed: boolean) => boolean;
+
+	/**
+	 * Callback to determine whether fixes should be applied to this commit.
+	 * Optional. If not provided, assumes yes.
+	 * <p><p>
+	 * fix: The FixUpInfo Object.<p>
+	 * return: True if to fix, false if not.
+	 */
+	applyFixCalback?: (fix: FixUpInfo) => boolean;
 }
 
 export interface IgnoreInfo {
@@ -259,7 +270,9 @@ export interface FixUpInfo {
 	sha: string;
 	newTitle?: string;
 	newBody?: string;
-	mode: FixUpMode;
+	mode: FixUpMode; // Auto Filled in If Not Provided
+	// Whether this fix should replace that other commit's fixes as well.
+	changeFixes?: boolean;
 }
 
 export interface ModInfo {


### PR DESCRIPTION
Saves a lot of repetition.