### PR TITLE
Fix dust-to-dye recipe conflicts

### DIFF
--- a/overrides/scripts/undyeing.zs
+++ b/overrides/scripts/undyeing.zs
@@ -7,10 +7,10 @@ recipes.addShapeless(<metaitem:dye.black>, [<minecraft:dye:0>]);
 <ore:dye>.remove(<minecraft:dye:3>);
 recipes.addShapeless(<metaitem:dye.brown>, [<minecraft:dye:3>]);
 <ore:dyeBrown>.remove(<nuclearcraft:cocoa_solids>);
-recipes.addShapeless(<metaitem:dye.brown>, [<nuclearcraft:cocoa_solids>]);
-recipes.addShapeless(<metaitem:dye.brown>, [<metaitem:dustCocoa>]); //NC cocoa solids and vanilla cocoa stop being a dye when turned into GT cocoa dust
+recipes.addShaped(<metaitem:dye.brown>, [[null,null,null], [null,null,null], [null,null,<nuclearcraft:cocoa_solids>]]);
+recipes.addShaped(<metaitem:dye.brown>, [[null,null,null], [null,null,null], [null,null,<metaitem:dustCocoa>]]); //NC cocoa solids and vanilla cocoa stop being a dye when turned into GT cocoa dust
 <ore:dyeBrown>.remove(<metaitem:dustMetalMixture>);
-recipes.addShapeless(<metaitem:dye.brown>, [<metaitem:dustMetalMixture>]);
+recipes.addShaped(<metaitem:dye.brown>, [[null,null,null], [null,null,null], [null,null,<metaitem:dustMetalMixture>]]);
 
 <ore:dyeBlue>.remove(<minecraft:dye:4>);
 <ore:dye>.remove(<minecraft:dye:4>);
@@ -20,18 +20,18 @@ recipes.addShapeless(<metaitem:dye.blue>, [<metaitem:gemLazurite>]);
 <ore:dyeBlue>.remove(<metaitem:gemSodalite>);
 recipes.addShapeless(<metaitem:dye.blue>, [<metaitem:gemSodalite>]);
 <ore:dyeBlue>.remove(<metaitem:dustLapis>);
-recipes.addShapeless(<metaitem:dye.blue>, [<metaitem:dustLapis>]);
+recipes.addShaped(<metaitem:dye.blue>, [[null,null,null], [null,null,null], [null,null,<metaitem:dustLapis>]]);
 <ore:dyeBlue>.remove(<metaitem:dustLazurite>);
-recipes.addShapeless(<metaitem:dye.blue>, [<metaitem:dustLazurite>]);
+recipes.addShaped(<metaitem:dye.blue>, [[null,null,null], [null,null,null], [null,null,<metaitem:dustLazurite>]]);
 <ore:dyeBlue>.remove(<metaitem:dustSodalite>);
-recipes.addShapeless(<metaitem:dye.blue>, [<metaitem:dustSodalite>]);
+recipes.addShaped(<metaitem:dye.blue>, [[null,null,null], [null,null,null], [null,null,<metaitem:dustSodalite>]]);
 
 <ore:dyeMagenta>.remove(<extrautils2:ingredients:3>);
 recipes.addShapeless(<metaitem:dye.magenta>, [<extrautils2:ingredients:3>]);
 
 <ore:dyeWhite>.remove(<minecraft:dye:15>);
 <ore:dye>.remove(<minecraft:dye:15>);
-recipes.addShapeless(<metaitem:dye.white>, [<minecraft:dye:15>]);
+recipes.addShaped(<metaitem:dye.white>, [[null,null,null], [null,null,null], [null,null,<minecraft:dye:15>]]);
 
 //fix elevator redyeing recipes
 recipes.removeByRecipeName("elevatorid:redye_white");


### PR DESCRIPTION
Crafting dusts into dyes no longer conflicts with uncrafting dusts into piles, but requires a crafting table