### PR TITLE
Improve Performance of URL Grabbing in Create Changelog

### DIFF
--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -6,7 +6,7 @@ import {
 	Ignored,
 	IgnoreLogic,
 	Parser,
-	SubCategory
+	SubCategory,
 } from "../../types/changelogTypes";
 import { modpackManifest } from "../../globals";
 import { parseCommitBody } from "./parser";


### PR DESCRIPTION
# Implementation Details
- If GITHUB_TOKEN is not set, Issue URL Grabbing is skipped.
- URL Cache is only grabbed *at the beginning* of changelog generation, not at the beginning of every iteration.
- Transform URL Tags are done at the end for all changelog messages at the same time. The promise that is returned from transforming URL tags is stored, and then resolved at the same time, leading to all URLs being transformed at the same time.

# Performance Comparison
*(On Slow WIFI, Iteration 1: Compare with 1.7-alpha-4, Iteration 2: Compare with 1.6.1a)*

## New Performance (On Slow WIFI)
7s Iteration 1
29s Iteration 2
Total: 36s

## Old Performance (On Slow WIFI)
8s Iteration 1
65.8s Iteration 2
Total: 1.23 min
