### PR TITLE
Only Grab URL Cache Once & Fix URL Transforming on GitHub

### DIFF
--- a/tools/tasks/changelog/createChangelog.ts
+++ b/tools/tasks/changelog/createChangelog.ts
@@ -9,7 +9,7 @@ import { parsers } from "./definitions";
 import parse from "./parser";
 import { specialParserSetup } from "./specialParser";
 import generateModChanges from "./generateModChanges";
-import pushAll, { pushChangelog, pushSeperator, pushTitle } from "./pusher";
+import pushAll, { pushChangelog, pushSeperator, pushSetup, pushTitle } from "./pusher";
 import log from "fancy-log";
 
 /**
@@ -19,6 +19,7 @@ async function createChangelog(): Promise<ChangelogData> {
 	const data: ChangelogData = new ChangelogData();
 
 	await data.init();
+	await pushSetup();
 
 	// Handle Iterations
 	if (data.shouldIterate()) {


### PR DESCRIPTION
GitHub does not auto provide the GITHUB_TOKEN env variable, and it is not required.

Furthermore, also only grabs the URL Cache Once, slightly improving performance. This was meant to be in #716, but I forgot to push the commit.