### PR TITLE
Fix Fish Oil Quest Task

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -23637,7 +23637,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1,
+              "Amount:3": 1000,
               "FluidName:8": "fish_oil"
             }
           },

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -28140,7 +28140,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1,
+              "Amount:3": 1000,
               "FluidName:8": "fish_oil"
             }
           },

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -28140,7 +28140,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1,
+              "Amount:3": 1000,
               "FluidName:8": "fish_oil"
             }
           },

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -23637,7 +23637,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1,
+              "Amount:3": 1000,
               "FluidName:8": "fish_oil"
             }
           },

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -153,6 +153,10 @@
       "expert": 402
     },
     {
+      "normal": 416,
+      "expert": 416
+    },
+    {
       "normal": 490,
       "expert": 490
     },


### PR DESCRIPTION
Fixes #746 

Sets the amount of fluid needed for the quest to a full bucket (1000mb) of Fish Oil.