### PR TITLE
Change Void Oil Deposit Back to Raw Oil

### DIFF
--- a/overrides/config/gregtech/worldgen/fluid/void/infinite_raw_oil_deposit.json
+++ b/overrides/config/gregtech/worldgen/fluid/void/infinite_raw_oil_deposit.json
@@ -1,9 +1,9 @@
 {
   "weight": 100,
-  "name": "Void Infinite Oil Deposit",
+  "name": "Void Infinite Raw Oil Deposit",
   "yield": {
-    "min": 40,
-    "max": 40
+    "min": 80,
+    "max": 80
   },
   "depletion": {
     "amount": 0,
@@ -13,5 +13,5 @@
   "dimension_filter": [
     "dimension_id:119"
   ],
-  "fluid": "oil"
+  "fluid": "oil_medium"
 }


### PR DESCRIPTION
This reverts a change made in #619 (specifically commits [`be70198` (#619)](https://github.com/Nomi-CEu/Nomi-CEu/pull/619/commits/be7019840ca837a8c35d3f38c5258bfd7740d5dd) and [`4220f6c` (#619)](https://github.com/Nomi-CEu/Nomi-CEu/pull/619/commits/4220f6c185318d6632d35ba2ec18b21adafd7981)), where the Void Raw Oil Deposit was changed from Raw Oil to Oil.

Although this was intended initially to maintain the same resource production as before the GregTech update, this decreased the production of Naphtha, leading to Gasoline and HoG being even less viable than before.

## Ratio Changes:
Before: 50mb (Oil) -> 20mb (Sulfuric Naphtha), Ratio of 5:2
After: 100mb (Raw Oil) -> 150mb (Sulfuric Naphtha), Ratio of 2:3

All other ratios are not changed (as Deposit has also been changed to give x2 amount).