### PR TITLE
Rebalance Expert Mode Endervoir Recipe to Output 4

### DIFF
--- a/overrides/scripts/expertmode.zs
+++ b/overrides/scripts/expertmode.zs
@@ -58,7 +58,7 @@ alloy.recipeBuilder()
 recipes.removeByRecipeName("enderio:reservoir");
 assembler.recipeBuilder()
 	.inputs([<ore:blockGlassHardened> * 18, <metaitem:nomilabs:plateDoubleEnergeticAlloy> * 3, <minecraft:cauldron>])
-	.outputs(<enderio:block_reservoir> * 3)
+	.outputs(<enderio:block_reservoir> * 4)
 	.duration(100)
 	.EUt(30)
 	.buildAndRegister();


### PR DESCRIPTION
This PR Rebalances Expert Mode Endervoir Recipe to Output 4, instead of 3.

This fits in better with the default recipe (like in NM), where 4 endervoirs are created per craft, and allows for one craft to perfectly make 4, the standard configuration of endervoirs.