### PR TITLE
Small Changelog Generation Fixes

### DIFF
--- a/tools/tasks/changelog/parser.ts
+++ b/tools/tasks/changelog/parser.ts
@@ -108,6 +108,9 @@ export async function parseCommitBody(
 	commitObject: Commit,
 	parser: Parser,
 ): Promise<boolean | Ignored> {
+	if (commitBody.includes(modInfoKey))
+		await parseModInfo(commitBody, commitObject);
+
 	if (commitBody.includes(expandKey)) {
 		await parseExpand(commitBody, commitObject, parser);
 		return true;
@@ -132,8 +135,6 @@ export async function parseCommitBody(
 		commitObject.priority = newPriority;
 	}
 
-	if (commitBody.includes(modInfoKey))
-		await parseModInfo(commitBody, commitObject);
 	if (commitBody.includes(detailsKey)) {
 		await parseDetails(commitMessage, commitBody, commitObject, parser);
 		return true;

--- a/tools/tasks/changelog/pusher.ts
+++ b/tools/tasks/changelog/pusher.ts
@@ -8,6 +8,12 @@ import { getIssueURL, getNewestIssueURLs } from "#utils/util.ts";
 let data: ChangelogData;
 let octokit: Octokit;
 
+// How many lines the changelog (excluding the commit log) can be before the commit log is excluded.
+const sectionLinesBeforeCommitLogExcluded = 50;
+
+// How many lines the commit log can be before its is excluded.
+const logLinesBeforeCommitLogExcluded = 20;
+
 export default async function pushAll(inputData: ChangelogData): Promise<void> {
 	pushTitle(inputData);
 	await pushChangelog(inputData);
@@ -65,12 +71,17 @@ export async function pushChangelog(inputData: ChangelogData): Promise<void> {
 
 	// Push the commit log
 	if (data.commitList.length > 0) {
-		sortCommitList(data.commitList, (commit) => commit);
+		if (
+			data.builder.length < sectionLinesBeforeCommitLogExcluded &&
+			data.commitList.length < logLinesBeforeCommitLogExcluded
+		) {
+			sortCommitList(data.commitList, (commit) => commit);
 
-		data.builder.push("## Commits");
-		data.commitList.forEach((commit) => {
-			data.builder.push(formatCommit(commit));
-		});
+			data.builder.push("## Commits");
+			data.commitList.forEach((commit) => {
+				data.builder.push(formatCommit(commit));
+			});
+		}
 	} else {
 		// No Commit List = No Changes
 		data.builder.push("");


### PR DESCRIPTION
This PR fixes two issues with the Changelog Generation:
- Fixes Mod Info Tags not being able to be in a commit body with Expand Tags
- Makes Commit Logs not appear after a certain size of changelog