### PR TITLE
Update Universal Tweaks to v1.11.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -417,11 +417,6 @@
       "required": true
     },
     {
-      "projectID": 271009,
-      "fileID": 2863246,
-      "required": true
-    },
-    {
       "projectID": 271384,
       "fileID": 2920434,
       "required": true

--- a/manifest.json
+++ b/manifest.json
@@ -696,7 +696,7 @@
     },
     {
       "projectID": 705000,
-      "fileID": 4929573,
+      "fileID": 5350889,
       "required": true
     },
     {

--- a/overrides/config/Universal Tweaks - Bugfixes.cfg
+++ b/overrides/config/Universal Tweaks - Bugfixes.cfg
@@ -25,12 +25,16 @@ general {
 
         # Disables climbing movement when flying
         B:"Ladder Flying Slowdown"=true
-
-        # Avoids the need for multiple mining attempts by sending additional movement packets
         B:"Mining Glitch"=true
 
         # Properly saves the last state of pistons to tags
         B:"Piston Progress"=true
+
+        # Improves retraction behavior on double piston extenders
+        B:"Piston Retraction"=false
+
+        # Fixes sleeping always resetting rain and thunder times
+        B:"Sleep Resets Weather"=true
 
         "block overlay" {
             # Fixes x-ray when standing in non-suffocating blocks
@@ -45,6 +49,15 @@ general {
             # Syntax: modid:block
             S:"[3] Whitelist" <
              >
+        }
+
+        "mining glitch" {
+            # Prevents ghost blocks by sending additional movement packets
+            B:"[1] Mining Glitch Toggle"=true
+
+            # Defines the maximum number of movement packets that can be sent per tick
+            # Vanilla default is 5
+            I:"[2] Maximum Movement Packets"=10
         }
 
     }
@@ -109,6 +122,9 @@ general {
         # Corrects maximum player health on joining by setting the last saved health value
         B:"Max Player Health"=true
 
+        # Fixes non-player entities being able to control minecarts
+        B:"Minecart AI"=true
+
         # Fixes mounts and boats sometimes disappearing after dismounting
         B:"Mount Desync"=true
 
@@ -121,12 +137,14 @@ general {
         # Fixes skeletons not looking at their targets when strafing
         B:"Skeleton Aim"=true
 
+        # Fixes untipped arrows emitting blue tipped arrow particles upon reloading a world
+        B:"Untipped Arrow Particles"=true
+
         # Returns missing hoods to villager mantles
         B:"Villager Mantle Hoods"=true
 
         "entity desync" {
             # Fixes entity motion desyncs most notable with arrows and thrown items
-            # Incompatible with Immersive Vehicles
             B:"[1] Entity Desync Toggle"=true
 
             # Syntax:  modid:entity
@@ -136,11 +154,22 @@ general {
              >
         }
 
+        "entity lists" {
+            # Fixes chunk entity lists often not getting updated correctly
+            B:"Chunk Updates"=true
+
+            # Fixes client-side memory leak where some entity ids are not set before being added to the world's entity list
+            B:"World Additions"=true
+        }
+
     }
 
     misc {
         # Improves the accuracy of smooth lighting by checking for suffocation and light opacity
         B:"Accurate Smooth Lighting"=true
+
+        # Fixes crafted item statistics not increasing correctly when items are crafted with shift-click or drop methods
+        B:"Crafted Item Statistics"=true
 
         # Fixes entity and particle rendering issues by enabling depth buffer writing
         B:"Depth Mask"=true
@@ -155,6 +184,15 @@ general {
         # Vanilla default is 0x200000
         # Incompatible with SpongeForge and RandomPatches
         I:"Packet Size"=16777216
+
+        # Fixes various particle types not showing up on the client
+        B:"Particle Spawning"=true
+
+        # Fixes potion effects not displaying their level above 'IV'
+        B:"Potion Amplifier Visibility"=true
+
+        # Fixes the spectator menu not showing player skins
+        B:"Spectator Menu"=true
 
         "model gap" {
             # Fixes transparent gaps in all 3D models of blocks and items
@@ -181,6 +219,9 @@ general {
         # Fixes invisible chunks in edge cases (small enclosed rooms at chunk borders)
         B:"Frustum Culling"=true
 
+        # Fixes duplication issues that can occur when entities travel through portals
+        B:"Portal Traveling Dupe"=true
+
         # Changes the data table of tile entities to resolve issues
         # HASHMAP:                   Vanilla default
         # LINKED_HASHMAP:            Keeps the loading order of tile entities to prevent issues during the first ticks of chunk loading
@@ -192,6 +233,9 @@ general {
         # CONCURRENT_HASHMAP
         # CONCURRENT_LINKED_HASHMAP
         S:"Tile Entity Map"=LINKED_HASHMAP
+
+        # Fixes witch hut structure data not accounting for the height it is generated at
+        B:"Witch Huts"=true
     }
 
 }

--- a/overrides/config/Universal Tweaks - Mod Integration.cfg
+++ b/overrides/config/Universal Tweaks - Mod Integration.cfg
@@ -3,13 +3,19 @@
 general {
 
     abyssalcraft {
-        # Makes an optimization to reduce tick overhead of AbyssalCraft's item transport system
+        # Disables AbyssalCraft's Plague-type mobs spawning lingering potion effects on death
+        B:"Disable Plague Potion Clouds"=false
+
+        # Optimizes AbyssalCraft's item transport system to reduce tick overhead
         B:"Optimized Item Transport"=true
     }
 
     "actually additions" {
         # Fixes various duplication exploits
         B:"Duplication Fixes"=true
+
+        # Fixes Laser Upgrades voiding instead of applying if there is only one item in the stack
+        B:"Laser Upgrade Voiding"=true
     }
 
     "arcane archives" {
@@ -18,7 +24,8 @@ general {
     }
 
     "advent of ascension" {
-        # Fixes AoA player ticking in certain GUIs without player inventories (i.e. Flux Networks GUI)
+        # Improves AoA player ticking by only sending inventory changes when necessary
+        B:"Improved Player Tick"=true
         B:"Inventory-less GUI Compatibility"=false
     }
 
@@ -34,7 +41,7 @@ general {
         # Optimizes the Hellfire/Soul Forge to reduce tick time
         B:"Optimized Hellfire Forge"=true
 
-        # Fixes memory leak related to unloading worlds/switching dimensions
+        # Fixes memory leak when unloading worlds/switching dimensions
         B:"World Unload Memory Leak Fix"=true
     }
 
@@ -70,6 +77,9 @@ general {
     }
 
     "elenai dodge 2" {
+        # Chance per dodge to extinguish the player when burning
+        D:"Extinguishing Dodges"=0.0
+
         # Fixes server-sided crashes when the Feathers Helper API is utilized
         B:"Feathers Helper API Fix"=true
 
@@ -89,13 +99,28 @@ general {
     }
 
     "the erebus" {
+        # Fixes Cabbage not dropping the correct items in some situations
+        B:"Fix Cabbage Drop"=true
+
+        # Fixes the Quake Hammer using the incorrect config option to control its size
+        B:"Fix Quake Hammer Texture"=true
+
         # Prevents HWYLA/TOP crashes with preserved blocks
         B:"Preserved Blocks Fix"=true
     }
 
     "extra utilities 2" {
+        # Fixes the Creative Mill Generator not respecting the Creative Block Breaking config
+        B:"Creative Mill Harvestability"=true
+
         # Fixes various duplication exploits
         B:"Duplication Fixes"=true
+
+        # Fixes Mob Attack and Health Statistics being repeatedly doubled
+        B:"Fix Deep Dark Stats"=true
+
+        # Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list
+        B:"Mutable Machine Block Drops"=true
     }
 
     forestry {
@@ -124,6 +149,9 @@ general {
         # Allows Forestry farms to pick up ExtraTrees fruit
         B:"Extra Trees: Gather Windfall"=true
 
+        # Fixes broken textures for various running and landing particles
+        B:"Particle Fixes"=true
+
         # Allows Forestry farms to automatically replant cocoa beans
         B:"Replanting Cocoa Beans"=true
     }
@@ -136,6 +164,9 @@ general {
     "industrial foregoing" {
         # Fixes various duplication exploits
         B:"Duplication Fixes"=true
+
+        # Fixes an off-by-one error where IF Machines would display the max tier of range addon as one less than the actual maximum
+        B:"Machines Max Range Off-By-One Fix"=true
     }
 
     "infernal mobs" {
@@ -177,7 +208,7 @@ general {
     }
 
     nuclearcraft {
-        # Changes the data table of the radiation environment handler to improve performance
+        # Changes the data table of the radiation environment handler to improve tick time
         # CONCURRENT_HASHMAP:        NuclearCraft default
         # CONCURRENT_LINKED_HASHMAP: Keeps order of radiation environment info to improve iteration - Better performance
         # CONCURRENT_LINKED_QUEUE:   Uses a queue to avoid iteration - Best performance
@@ -199,16 +230,11 @@ general {
     }
 
     roost {
-        # Improves load time by registering CT chickens early for Roost to detect them
-        # Note: All CT chickens must be specified in "Custom Chickens" for this tweak to work!
-        # Note: In your .zs files, to use ContentTweaker's MaterialSystem Parts, you must:
+        # Improves load time by registering ContentTweaker chickens early for Roost to detect them
+        # Note: If you would like to use ContentTweaker's MaterialSystem Parts for the layed item, in your script you must:
         # 1) Use '#loader finalize_contenttweaker', not '#loader contenttweaker'
         # 2) Use the Material Part Bracket Handler to reference the item
         B:"ContentTweaker: Early Register CT Chickens"=false
-
-        # Adds custom chickens from mods (e.g. ContentTweaker) to Roost's stock texture check
-        # Syntax: name
-        # name     Chicken name
         S:"Custom Chickens" <
          >
     }
@@ -356,6 +382,11 @@ general {
         S:"Material Blacklist" <
          >
 
+        # Determines the maximum number of possible items to display before not rendering any to prevent substantial lag
+        # 0 to disable rendering items in the smeltery entirely
+        # -1 for the default, which is always rendering items
+        I:"Maximum Items to Render in Smeltery"=-1
+
         # Suppresses special abilities of long swords and rapiers when shurikens are wielded in the offhand
         B:"Offhand Shuriken"=true
 
@@ -364,11 +395,90 @@ general {
 
         # Despawns unbreakable projectiles faster to improve framerates
         B:"Projectile Despawning"=true
+
+        # Enables usage of tweaks in below category to customize Tinkers' tools stats
+        B:"Tool Customization"=true
+
+        "tool customization" {
+            # Sets the rate at which a tool's attack damage incrementally decays depending on its damage cutoff
+            # Default value: 0.9
+            # Range: 0.0 - 1.0
+            # Note: A rate of 1.0 means there is no damage decay
+            # Note: The damage curve will cap the maximum value to (tool's damage cutoff)/(1 - decay rate)
+            S:"Attack Damage Decay Rate"=0.9
+
+            # Sets the attack damage cutoff at which diminishing returns start for the cleaver
+            # Default value: 25.0
+            D:"Cleaver Attack Damage Cutoff"=25.0
+
+            # Sets the attack damage cutoff at which diminishing returns start for any Tinkers' tool not listed here
+            # Default value: 15.0
+            D:"General Attack Damage Cutoff"=15.0
+
+            # Sets the attack damage cutoff at which diminishing returns start for the longsword
+            # Default value: 18.0
+            D:"Longsword Attack Damage Cutoff"=18.0
+
+            # Sets the attack damage cutoff at which diminishing returns start for the PlusTiC katana
+            # Default value: 22.0
+            D:"PlusTiC: Katana Attack Damage Cutoff"=22.0
+
+            # Sets the attack damage cutoff at which diminishing returns start for the rapier
+            # Default value: 13.0
+            D:"Rapier Attack Damage Cutoff"=13.0
+        }
+
     }
 
     "tiny progressions" {
         # Fixes various duplication exploits
         B:"Duplication Fixes"=true
+    }
+
+    "astral sorcery" {
+        # Fixes a bug where particle effects would continue to render after changing dimensions
+        B:"Clear Particle Effects"=true
+
+        # Downgrades the message when completing a recipe without an initializing player from a warning to a debug
+        B:"Downgrade Missing Player Log Level"=true
+
+        # Fixes Sooty Marble Pillar blocking the proper rendering of adjacent fluids due to inverted logic
+        B:"Sooty Marble Rendering Fix"=true
+    }
+
+    "cb multipart/forge multipart cbe" {
+        # Fixes a memory leak associated with EntityPlayer
+        B:"Memory Leak Fix"=true
+    }
+
+    "compact machines" {
+        # Fixes some compact machine walls being invisible if Nothirium 0.2.x (and up) or Vintagium is installed
+        B:"Invisible Wall Render Fix"=true
+    }
+
+    "effortless building" {
+        # Fixes Effortless Building ignoring Metadata when checking for items in inventory
+        B:"Block Transmutation Fix"=false
+    }
+
+    "modular routers" {
+        # Fixes particles being added from the wrong thread which corrupted the particle manager
+        B:"Particle Thread Fix"=true
+    }
+
+    mrtjpcore {
+        # Fixes a memory leak associated with EntityPlayer
+        B:"Memory Leak Fix"=true
+    }
+
+    railcraft {
+        # Disables the beta message warning on world join
+        B:"No Beta Warning"=true
+    }
+
+    "rftools dimensions" {
+        # Fixes a bug where joining a world or server with any RFTools Dimension registered would disallow entering another world without that dimension until restarting
+        B:"Fully Unregister Dimensions"=true
     }
 
 }

--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -15,6 +15,30 @@ general {
         # Determines how tall cacti can grow
         I:"Cactus Size"=3
 
+        # Allows placing End Crystals without requiring Obsidian or Bedrock below
+        B:"End Crystal Placing"=false
+
+        # Determines the numerator of the block drop formula on explosions
+        # Formula: chance ÷ explosionSize
+        D:"Explosion Block Drop Chance"=1.0
+
+        # Determines how long falling blocks remain in ticks until they are dropped under normal circumstances
+        I:"Falling Block Lifespan"=600
+
+        # Controls when and if farmland can be trampled into dirt
+        # Default: Farmland is trampled normally (vanilla default)
+        # Never: Farmland can never be trampled
+        # Only Player: Prevents farmland from being trampled by a non-EntityPlayer
+        # Not Player: Prevents farmland from being trampled by an EntityPlayer
+        # Feather Falling: Prevents farmland from being trampled if the entity has the Feather Falling enchantment on equipped boots
+        # Valid values:
+        # DEFAULT
+        # NEVER
+        # ONLY_PLAYER
+        # NOT_PLAYER
+        # FEATHER_FALLING
+        S:"Farmland Trample"=DEFAULT
+
         # Makes leaves decay faster when trees are chopped
         B:"Fast Leaf Decay"=true
 
@@ -26,6 +50,9 @@ general {
 
         # Determines how tall sugar cane can grow
         I:"Sugar Cane Size"=3
+
+        # Allows placing Pumpkins and Jack'O'Lanterns without a supporting block
+        B:"Unsupported Pumpkin Placing"=false
 
         # Determines how long vines can grow
         # 0 = Infinite (vanilla default)
@@ -100,6 +127,57 @@ general {
             I:"[4] Maximum Altitude"=63
         }
 
+        "overhaul beacon" {
+            # Overhaul beacon construction and range
+            B:"[1] Overhaul Beacon Toggle"=false
+
+            # Modifier: Use per block modifier for range calculation, replacing vanilla implementation
+            # Enforced: Enforce usage of only 1 beacon base type per level
+            # Valid values:
+            # MODIFIER
+            # ENFORCED
+            # ENFORCED_MODIFIER
+            S:"[2] Mode"=ENFORCED
+
+            # Global range for block, change it by modify beacon range config
+            D:"[3] Global Modifier"=1.0
+
+            # Scaling beacon range per level (1 -> 4)
+            # Don't try add more value to this scale as this only use first 4 values
+            D:"[4] Level Scaling" <
+                1.0
+                0.8
+                0.6
+                0.4
+             >
+
+            ##########################################################################################################
+            # [5] per block modifier
+            #--------------------------------------------------------------------------------------------------------#
+            # Block modifier for range calculate, only apply for beacon base block
+            # Add new one required restart, modify doesn't required so
+            ##########################################################################################################
+
+            "[5] per block modifier" {
+                D:"modid:example"=1.0
+            }
+
+        }
+
+        "sapling behavior" {
+            # Allows customization of sapling behavior while utilizing an optimized method
+            B:"[1] Sapling Behavior Toggle"=true
+
+            # Inclusive minimum light level at which saplings grow into trees
+            I:"[2] Minimum Light Level"=9
+
+            # Chance per update tick at which saplings grow into trees
+            # Note: General growth rate is still affected by the random tick speed
+            # Min: 0.0
+            # Max: 1.0
+            D:"[3] Growth Chance"=0.125
+        }
+
     }
 
     entities {
@@ -108,6 +186,14 @@ general {
 
         # Replaces entity AI for improved server performance
         B:"AI Replacement"=true
+
+        # Scales dropped experience from entities based on their health
+        # Formula: max_health * factor
+        # 0 for vanilla default
+        D:"Adaptive XP Drops"=0.0
+
+        # Enables arms for armor stands by default
+        B:"Armed Armor Stands"=false
 
         # Replaces auto jump with an increased step height (singleplayer only)
         B:"Auto Jump Replacement"=true
@@ -125,10 +211,6 @@ general {
         # Min: 0.0
         # Max: 1.0
         D:"Creeper Charged Spawning Chance"=0.0
-
-        # Sets the chance to replace deadly creeper explosions with delightful confetti
-        # Min: 0.0
-        # Max: 1.0
         D:"Creeper Confetti Spawning Chance"=0.0
 
         # Sets the additional damage that critical arrows deal
@@ -141,14 +223,26 @@ general {
         # Disables leveling of villager careers, only allowing base level trades
         B:"Disable Villager Trade Leveling"=false
 
+        # Disables restocking of villager trades, only allowing one trade per offer
+        B:"Disable Villager Trade Restock"=false
+
         # Disables withers targeting animals
         B:"Disable Wither Targeting AI"=false
+
+        # Sets the offset for the fire overlay in first person when the player is burning
+        D:"First Person Burning Overlay"=-0.3
 
         # Lets husks and strays spawn underground like regular zombies and skeletons
         B:"Husk & Stray Spawning"=true
 
         # Mobs carrying picked up items will drop their equipment and despawn properly
         B:"Mob Despawn Improvement"=true
+
+        # Backports 1.16+ knockback to 1.12: Knockback resistance is now a scale instead of a probability
+        B:"Modern Knockback"=true
+
+        # Prevents zombie pigmen spawning from nether portals
+        B:"No Portal Spawning"=false
 
         # Stops horses wandering around when saddled
         B:"No Saddled Wandering"=true
@@ -162,6 +256,20 @@ general {
         # Min: 0.0
         # Max: 1.0
         D:"Rabbit Toast Spawning Chance"=0.0
+
+        # Sets the exhaustion value per cm when riding mounts
+        # Min: 0.0
+        # Max: 1.0
+        D:"Riding Exhaustion"=0.0
+
+        # Summoned vexes will also die when their summoner is killed
+        B:"Soulbound Vexes"=true
+
+        # Allows creating Iron Golems with non-air blocks in the bottom corners of the structure
+        B:"Weaken Golem Structure Requirements"=false
+
+        # Allows creating Withers with non-air blocks in the bottom corners of the structure
+        B:"Weaken Wither Structure Requirements"=false
 
         attributes {
             # Sets custom ranges for entity attributes
@@ -333,6 +441,101 @@ general {
             D:"[2] Damage Reduction"=2.0
         }
 
+        "chicken shedding" {
+            # Enables chickens to have a chance to shed a feather
+            B:"[1] Chicken Shedding"=true
+
+            # How frequently feathers shed from chickens (lower means more)
+            I:"[2] Shed Frequency"=28000
+
+            # Allows baby chickens to also shed feathers
+            B:"[3] Baby Chickens Shed Feathers"=false
+        }
+
+        "cobweb slowness" {
+            # Modifies the applied slowness factor when entities are moving in cobwebs
+            B:"[1] Cobweb Slowness Toggle"=false
+
+            # The slowness factor that gets multiplied with the horizontal entity speed
+            D:"[2] Horizontal Slowness Factor"=0.25
+
+            # The slowness factor that gets multiplied with the vertical entity speed
+            D:"[3] Vertical Slowness Factor"=0.05000000074505806
+        }
+
+        "creeper confetti" {
+            # Sets the chance to replace deadly creeper explosions with delightful confetti
+            # Min: 0.0
+            # Max: 1.0
+            D:"[1] Creeper Confetti Chance"=0.0
+
+            # Sets the damage dealt by confetti explosions
+            D:"[2] Creeper Confetti Damage"=0.0
+        }
+
+        "void teleport" {
+            # Enables Void Teleport, where falling out below a dimension will teleport you to the top of the dimension
+            B:"[01] Void Teleport Toggle"=true
+
+            # Prevents taking a tick of void damage before being teleported
+            # If this is false, entities will take 4 damage every time Void Teleport activates, preventing infinite looping
+            B:"[02] Prevent Void Damage"=true
+
+            # Y-level to teleport the entity
+            # If the target Y-level is lower than the highest block in that coordinate, will teleport the entity to the highest location instead
+            I:"[03] Target Y-Level"=300
+
+            # Applies the blindness effect for 3 seconds when teleporting
+            B:"[04] Apply Blindness on Teleport"=true
+
+            # Prevents Y motion from being less than this
+            D:"[05] Clamp Falling Speed"=-1.0
+
+            # Height to override the fallDistance variable with when landing after having teleported
+            # When set to less than 0, [07] Fall Damage Taken applies instead
+            D:"[06] Fall Distance Height"=-1.0
+
+            # Amount of fall damage taken when landing on a block
+            # Negative numbers deal damage relative to the entity's max health
+            # Only applies if [06] Fall Distance Height is less than 0
+            D:"[07] Fall Damage Taken"=-1.0
+
+            # Sets if [07] Fall Damage Taken can kill entities
+            # Does not apply to fall damage taken due to [06] Fall Distance Height
+            B:"[08] Allow Fall Damage Taken to Kill"=true
+
+            # Maximum number of times to teleport the entity without the entity landing before no longer teleporting. Used to prevent infinite loops
+            I:"[09] Maximum Times to Teleport Consecutively"=500
+
+            # Controls if players are teleported by Void Teleport
+            B:"[10] Apply Void Teleport to Players"=true
+
+            # List of the resource location names for entities concerning Void Teleport
+            # Behavior depends on the list mode
+            S:"[11] Entity List" <
+             >
+
+            # Blacklist Mode: Entities that won't be impacted by Void Teleport, others will
+            # Whitelist Mode: Entities that will be impacted by Void Teleport, others won't
+            # Valid values:
+            # WHITELIST
+            # BLACKLIST
+            S:"[12] Entity List Mode"=WHITELIST
+
+            # List of dimensions concerning Void Teleport
+            # Behavior depends on the list mode
+            # Can be dimension name or ID
+            S:"[13] Dimension List" <
+             >
+
+            # Blacklist Mode: Dimensions that don't have Void Teleport enabled, others do
+            # Whitelist Mode: Dimensions that have Void Teleport enabled, others don't
+            # Valid values:
+            # WHITELIST
+            # BLACKLIST
+            S:"[14] Dimension List Mode"=BLACKLIST
+        }
+
     }
 
     items {
@@ -341,8 +544,6 @@ general {
 
         # Switches the selected hotbar slot to a proper tool if required
         B:"Auto Switch Tools"=false
-
-        # Bows enchanted with Infinity no longer require arrows
         B:"Bow Infinity"=true
 
         # Sets custom rarities for items, affecting tooltip colors
@@ -476,14 +677,26 @@ general {
 
             # Makes item entities flash faster as they get closer to despawning
             B:"[16] Clear Despawn: Urgent Flashing"=true
+
+            # Slows how often item entities update their position to improve performance
+            B:"[17] Slowed Movement"=false
         }
 
         mending {
+            # Bows enchanted with Infinity no longer require arrows
+            B:"[1] Arrowless Infinity"=true
+
             # Implements modern mending behavior to only repair damaged equipment with XP
             B:"[1] Mending Toggle"=true
 
+            # Allows the Infinity Enchantment to be combined with Mending
+            B:"[2] Infinity Conflict"=true
+
             # Determines the amount of durability mending will repair, on average, per point of experience
             D:"[2] Ratio"=2.0
+
+            # Allows the Infinity Enchantment to apply to all arrows (e.g. Tipped Arrows)
+            B:"[3] Infinity Affects All Arrows"=true
 
             # Repairs damaged items from the entire inventory with XP
             B:"[3] Overpowered"=true
@@ -539,6 +752,12 @@ general {
     }
 
     misc {
+        # Always displays the actual potion duration instead of `**:**`
+        B:"Accurate Potion Duration"=true
+
+        # Displays the ping in milliseconds of players when viewing the server list
+        B:"Better Ping Display"=true
+
         # Enables clicking of `/seed` world seed in chat to copy to clipboard
         B:"Copy World Seed"=true
 
@@ -553,18 +772,37 @@ general {
         # HARD
         S:"Default Difficulty"=PEACEFUL
 
+        # Prevents the advancement system from loading entirely
+        B:"Disable Advancements"=true
+
         # Disables the narrator functionality entirely
-        B:"Disable Narrator"=true
+        B:"Disable Narrator"=false
+
+        # Disables all text shadowing, where text has a darker version of itself rendered behind the normal text, changing the appearance and can improve fps on some screens
+        B:"Disable Text Shadows"=false
 
         # Re-implements parallax rendering of the end portal from 1.10 and older
         B:"End Portal Parallax"=true
 
+        # Disables potion effect particles emitting from yourself
+        B:"Hide Personal Effect Particles"=false
+
+        # Provides more information to addPacket removed entity warnings
+        B:"Improved Entity Tracker Warning"=true
+
         # Lets background music play continuously without delays
         B:"Infinite Music"=false
+
+        # Enhance the vanilla 'Open to LAN' GUI for listening port customization, removal of enforced authentication and more
+        B:"LAN Server Properties"=true
 
         # Sets the amount of XP needed for each level, effectively removing the increasing level scaling
         # 0 for vanilla default
         I:"Linear XP Amount"=0
+
+        # Sets the amount of applicable pattern layers for banners
+        # 6 for vanilla default
+        I:"More Banner Layers"=6
 
         # Disables the flashing effect when the night vision potion effect is about to run out
         B:"No Night Vision Flash"=true
@@ -581,6 +819,12 @@ general {
         # Sets the Y value of the overlay message (action bar), displayed for playing records etc.
         # -4 for vanilla default
         I:"Overlay Message Height"=-4
+
+        # Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present
+        B:"Prevent Keybinds from Overflowing Screen"=true
+
+        # Removes the 3D Anaglyph button from the video settings menu
+        B:"Remove 3D Anaglyph Button"=true
 
         # Removes the redundant Minecraft Realms button from the main menu
         # Incompatible with RandomPatches
@@ -605,6 +849,11 @@ general {
 
         # Adds a button to the pause menu to toggle cheats
         B:"Toggle Cheats Button"=true
+
+        # Sets the maximum experience level players can reach
+        # 0 to effectively disable gaining of experience
+        # -1 for vanilla default
+        I:"XP Level Cap"=-1
 
         "armor curve" {
             # Adjusts the armor scaling and degradation formulae for mobs and players
@@ -662,6 +911,9 @@ general {
 
             # Disables the flashing of skybox and ground brightness on lightning bolt strikes
             B:"No Lightning Flash"=false
+
+            # Prevents lightning bolts from destroying items
+            B:"No Lightning Item Destruction"=false
         }
 
         "load sounds" {
@@ -796,6 +1048,38 @@ general {
 
             # Determines if tutorial toasts are blocked. Blocks useless things like use WASD to move.
             B:"[5] Disable Tutorial Toasts"=true
+
+            # List of class names of Toasts to prevent displaying
+            # Behavior depends on the list mode
+            # Syntax: full class name
+            S:"[6] Toast Control List" <
+             >
+
+            # Blacklist Mode: Toast classes which can't be added to the queue, others can
+            # Whitelist Mode: Toast classes which can be added to the queue, others can't
+            # Valid values:
+            # WHITELIST
+            # BLACKLIST
+            S:"[7] List Mode"=BLACKLIST
+
+            # Enables debug logging to log class names of displayed toasts to the log
+            B:"[8] Debug Logging"=false
+
+            # Enables a keybind (default: CTRL+0) to clear all active toasts
+            B:"[9] Clear Toast Keybind"=true
+        }
+
+        chat {
+            # Sets the maximum number of chat lines to display
+            # 100 is the vanilla default
+            # 0 or less functionally disables the chat
+            I:"[1] Chat Lines"=100
+
+            # Don't clear sent message history on leaving the world
+            B:"[2] Keep Sent Messages"=false
+
+            # Removes duplicate messages and instead put a number behind the message how often it was repeated
+            B:"[3] Compact Messages"=true
         }
 
     }
@@ -816,6 +1100,9 @@ general {
         # Improves rendering performance by removing the resource location text on missing models
         B:"Disable Fancy Missing Model"=true
 
+        # Improves rendering performance by disabling rendering the entity inside mob spawners
+        B:"Disable Mob Spawner Entity"=false
+
         # Replaces color lookup for sheep to check a predefined table rather than querying the recipe registry
         B:"Fast Dye Blending"=true
 
@@ -829,11 +1116,51 @@ general {
         # Fixes slow background startup edge case caused by checking tooltips during the loading process
         B:"Faster Background Startup"=true
 
+        # Silences advancement errors
+        B:"Mute Advancement Errors"=false
+
+        # Silences ore dictionary errors
+        B:"Mute Ore Dictionary Errors"=false
+
+        # Silences texture map errors
+        B:"Mute Texture Map Errors"=false
+
+        # Disables mob pathfinding from loading new/unloaded chunks when building chunk caches
+        B:"No Pathfinding Chunk Loading"=true
+
         # Disables lighting of active redstone, repeaters, and comparators to improve performance
         B:"No Redstone Lighting"=false
 
         # Removes the hardcoded 30 FPS limit in screens like the main menu
         B:"Uncap FPS"=true
+
+        "entity radius check" {
+            # Toggles all tweaks in this category
+            # IMPORTANT: These tweaks are only effective if you have mod(s) that increase World.MAX_ENTITY_RADIUS!
+            # (Lycanites Mobs, Advanced Rocketry, Immersive Railroading, etc.)
+            B:"[1] Entity Radius Check Toggle"=true
+
+            # Reduces the search size of various AABB functions for specified entity types
+            B:"[2] Reduce Search Size Toggle"=true
+
+            # The entity types to reduce the search size for
+            # Syntax - modid:name
+            S:"[3] Reduce Search Size Targets" <
+                minecraft:item
+                minecraft:player
+             >
+
+            # Reduces size of collision checks for most vanilla and specified entity types
+            B:"[4] Less Collisions Toggle"=true
+
+            # The extra entity types to reduce the size of collision checks for
+            # Syntax - modid:name;radius
+            # Vanilla ids aren't allowed because they are already included
+            # Most types should be specified with the vanilla default radius: 2.0
+            S:"[5] Less Collisions Extra Targets" <
+             >
+        }
+
     }
 
     world {
@@ -841,11 +1168,16 @@ general {
         # Vanilla default is 63
         I:"Sea Level"=63
 
-        # Replaces stronghold generation with a safer variant
+        # Enforces stronghold generation to generate all blocks, regardless of air
+        B:"Stronghold Enforcement"=true
         B:"Stronghold Replacement"=true
 
         # Tidies newly generated chunks by removing scattered item entities
         B:"Tidy Chunk"=false
+
+        # Sets the village generation distance in chunks
+        # Vanilla default is 32
+        I:"Village Distance"=32
 
         "chunk gen limit" {
             # Limits maximum chunk generation per tick for improved server performance
@@ -872,6 +1204,46 @@ general {
                 0
                 overworld
              >
+        }
+
+        "void fog" {
+            # Determines the amount of iterations for checking void particle spawns per animate tick
+            I:"[10] Particle Spawn Iterations"=1000
+
+            # Re-implements pre-1.8 void fog and void particles
+            B:"[1] Void Fog Toggle"=false
+
+            # List of dimensions concerning void fog and particles
+            # Behavior depends on the list mode
+            # Can be dimension name or ID
+            S:"[2] Dimension List" <
+                overworld
+             >
+
+            # Blacklist Mode: Dimensions that don't have void fog and particles enabled, others do
+            # Whitelist Mode: Dimensions that have void fog and particles enabled, others don't
+            # Valid values:
+            # WHITELIST
+            # BLACKLIST
+            S:"[3] Dimension List Mode"=WHITELIST
+
+            # Renders void fog in creative and spectator mode
+            B:"[4] Fog In Creative/Spectator"=false
+
+            # Renders void fog in the superflat world type
+            B:"[5] Fog In Superflat"=false
+
+            # Renders void fog when the player has night vision
+            B:"[6] Fog On Night Vision"=false
+
+            # Renders void particles in creative and spectator mode
+            B:"[7] Particles In Creative/Spectator"=true
+
+            # Renders void particles in the superflat world type
+            B:"[8] Particles In Superflat"=false
+
+            # Determines the maximum Y level of the player at which void particles are spawned
+            I:"[9] Particle Spawn Y Level"=8
         }
 
     }


### PR DESCRIPTION
This PR updates Universal Tweaks to v1.11.0.

v1.11.0 implements a version of Forgiving Void (Called Void Teleport), allowing Forgiving Void (The Mod) to be removed.

v1.11.0 also fixes a transmutation bug with Effortless Building. However, Nomi-Labs has that fix as well as other fixes relating to Effortless Building, so that fix has been disabled, preferring the Labs fix instead.