### PR TITLE
Tooltip Fixes and Enhancements

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -146,6 +146,49 @@ if (!AEConfig.instance().isFeatureEnabled(AEFeature.CHANNELS)) {
 // Facades
 addTooltip(item('appliedenergistics2:facade'), translatable('nomiceu.tooltip.ae2.facade'))
 
+// Crafting Storages
+var craftingStorages = [
+	item('appliedenergistics2:crafting_storage_1k'),
+	item('appliedenergistics2:crafting_storage_4k'),
+	item('appliedenergistics2:crafting_storage_16k'),
+	item('appliedenergistics2:crafting_storage_64k'),
+	item('nae2:storage_crafting_256k'),
+	item('nae2:storage_crafting_1024k'),
+	item('nae2:storage_crafting_4096k'),
+	item('nae2:storage_crafting_16384k'),
+]
+for (ItemStack crafting : craftingStorages) {
+	addTooltip(crafting, translatable('nomiceu.tooltip.ae2.crafting_storage'))
+}
+
+// Storage Cells
+var storageCells = [
+	item('appliedenergistics2:storage_cell_1k'),
+	item('appliedenergistics2:storage_cell_4k'),
+	item('appliedenergistics2:storage_cell_16k'),
+	item('appliedenergistics2:storage_cell_64k'),
+	item('appliedenergistics2:fluid_storage_cell_1k'),
+	item('appliedenergistics2:fluid_storage_cell_4k'),
+	item('appliedenergistics2:fluid_storage_cell_16k'),
+	item('appliedenergistics2:fluid_storage_cell_64k'),
+	item('nae2:storage_cell_void'),
+	item('nae2:fluid_storage_cell_void'),
+	item('nae2:storage_cell_256k'),
+	item('nae2:storage_cell_1024k'),
+	item('nae2:storage_cell_4096k'),
+	item('nae2:storage_cell_16384k'),
+	item('nae2:storage_cell_fluid_256k'),
+	item('nae2:storage_cell_fluid_1024k'),
+	item('nae2:storage_cell_fluid_4096k'),
+	item('nae2:storage_cell_fluid_16384k'),
+]
+for (ItemStack storage : storageCells) {
+	addTooltip(storage, [
+		translatableEmpty(),
+		translatable('nomiceu.tooltip.ae2.storage_cell'),
+	])
+}
+
 /* Dimensional Edibles */
 
 // Island Cake

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -189,6 +189,11 @@ for (ItemStack storage : storageCells) {
 	])
 }
 
+// Quartz Knives
+for (ItemStack knife : [item('appliedenergistics2:nether_quartz_cutting_knife'), item('appliedenergistics2:certus_quartz_cutting_knife')]) {
+	addTooltip(knife, translatable('nomiceu.tooltip.ae2.quartz_knife'))
+}
+
 /* Dimensional Edibles */
 
 // Island Cake

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -52,6 +52,8 @@ nomiceu.tooltip.ae2.channels_not_enabled=Channels not enabled!
 nomiceu.tooltip.ae2.controller=§bThe ME Controller reduces your AE2 system's power consumption!§r
 nomiceu.tooltip.ae2.dense=§bFor decoration!§r
 nomiceu.tooltip.ae2.facade=§3AE2 facades can be made from most non-tile-entities.§r
+nomiceu.tooltip.ae2.crafting_storage=§ePlace this into a Crafting Grid to recycle it!§r
+nomiceu.tooltip.ae2.storage_cell=§eShift Right Click whilst holding this to recycle it!§r
 
 # Dimensional Edibles
 nomiceu.tooltip.dimensionaledibles.island_cake.1=§aUsed by Server Owners to send FTB Teams and Individuals to their Personal Islands!§r

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -75,7 +75,8 @@ nomiceu.tooltip.gregtech.facade.1=§3GTCEu facades can be made from most non-til
 nomiceu.tooltip.gregtech.facade.2=§3They craft into different amounts based on the metal used!§r
 
 # Extended Crafting
-nomiceu.tooltip.extendedcrafting.black_steel.omnium=§7Omnium Trimmed§r
+nomiceu.tooltip.extendedcrafting.black_steel.omnium.1=Block of Black Steel
+nomiceu.tooltip.extendedcrafting.black_steel.omnium.2=§7Omnium Trimmed§r
 
 # Project Red
 nomiceu.tooltip.projectred.wire=§eFor use with ProjectRed.§r

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -54,6 +54,7 @@ nomiceu.tooltip.ae2.dense=§bFor decoration!§r
 nomiceu.tooltip.ae2.facade=§3AE2 facades can be made from most non-tile-entities.§r
 nomiceu.tooltip.ae2.crafting_storage=§ePlace this into a Crafting Grid to recycle it!§r
 nomiceu.tooltip.ae2.storage_cell=§eShift Right Click whilst holding this to recycle it!§r
+nomiceu.tooltip.ae2.quartz_knife=§eRight Click on placed ME parts to rename them... for free!§r
 
 # Dimensional Edibles
 nomiceu.tooltip.dimensionaledibles.island_cake.1=§aUsed by Server Owners to send FTB Teams and Individuals to their Personal Islands!§r


### PR DESCRIPTION
This PR makes three changes:
- Fixes the Black Steel tooltip added in https://github.com/Nomi-CEu/Nomi-CEu/pull/796
- Adds tooltips for AE2 Storage Cells and Crafting Storages, stating how they are recycled
- Adds a tooltip for AE2 Knives, stating how they rename AE2 parts