### PR TITLE
Replace AE2 Stuff with AE2 Stuff Unofficial

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -76,11 +76,6 @@
       "required": true
     },
     {
-      "projectID": 225194,
-      "fileID": 2491032,
-      "required": true
-    },
-    {
       "projectID": 225561,
       "fileID": 2678374,
       "required": true
@@ -762,6 +757,11 @@
     {
       "projectID": 945503,
       "fileID": 4941450,
+      "required": true
+    },
+    {
+      "projectID": 951064,
+      "fileID": 5002181,
       "required": true
     }
   ]


### PR DESCRIPTION
This PR actually replaces AE2 Stuff with AE2 Stuff Unofficial, which was already setup in https://github.com/Nomi-CEu/Nomi-CEu/pull/790, but the actual mod change was not made.