### PR TITLE
Fix Advanced Disclocator Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/draconicFusion.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/draconicFusion.groovy
@@ -7,8 +7,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('actuallyadditions:block_crystal_empowered', 4))
 	.input(metaitem('blockNetherStar'), metaitem('blockNetherStar'), item('draconicevolution:draconic_core'), item('draconicevolution:draconic_core'), item('draconicevolution:draconic_core'), item('draconicevolution:draconic_core'), item('armorplus:block_compressed_infused_lava_crystal'), item('armorplus:block_compressed_infused_lava_crystal'))
 	.output(item('draconicevolution:wyvern_core'))
-	.energy(21943000)
-	.tierNormal()
+	.energy(22_000_000).tierNormal()
 	.register()
 
 // Chaotic Solar Panel
@@ -17,8 +16,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:chaotic_core'))
 	.input(item('solarflux:solar_panel_draconic'), item('draconicevolution:draconic_energy_core'), item('draconicevolution:draconic_energy_core'), item('solarflux:solar_panel_draconic'))
 	.output(item('solarflux:solar_panel_chaotic') * 2)
-	.energy(3355440000)
-	.tierChaotic()
+	.energy(3_250_000_000).tierChaotic()
 	.register()
 
 // Neutronium Solar Panel
@@ -26,8 +24,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('solarflux:solar_panel_chaotic'))
 	.input(item('draconicevolution:chaotic_core'), item('draconicevolution:chaotic_core'), metaitem('nomilabs:wireGtSingleDraconicSuperconductor'), metaitem('nomilabs:wireGtSingleDraconicSuperconductor'), item('extendedcrafting:storage', 4), item('extendedcrafting:storage', 4), metaitem('nomilabs:wireGtSingleDraconicSuperconductor'), metaitem('nomilabs:wireGtSingleDraconicSuperconductor'), item('draconicevolution:chaotic_core'), item('draconicevolution:chaotic_core'))
 	.output(item('solarflux:solar_panel_neutronium'))
-	.energy(13421760000)
-	.tierChaotic()
+	.energy(13_500_000_000).tierChaotic()
 	.register()
 
 // Draconic Solar Panel
@@ -35,8 +32,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:draconic_energy_core'))
 	.input(item('solarflux:solar_panel_wyvern'), item('solarflux:solar_panel_wyvern'), item('enderio:item_endergy_conduit', 11), item('enderio:item_endergy_conduit', 11), item('draconicevolution:wyvern_energy_core'), item('draconicevolution:wyvern_energy_core'), item('enderio:item_endergy_conduit', 11), item('enderio:item_endergy_conduit', 11), item('solarflux:solar_panel_wyvern'), item('solarflux:solar_panel_wyvern'))
 	.output(item('solarflux:solar_panel_draconic') * 2)
-	.energy(1677720000)
-	.tierDraconic()
+	.energy(1_750_000_000).tierDraconic()
 	.register()
 
 // Wyvern Solar Panel
@@ -44,8 +40,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:wyvern_energy_core'))
 	.input(item('solarflux:solar_panel_8'), item('solarflux:solar_panel_8'), item('enderio:item_endergy_conduit', 10), item('enderio:item_endergy_conduit', 10), metaitem('nomilabs:blockDraconium'), metaitem('nomilabs:blockDraconium'), item('enderio:item_endergy_conduit', 10), item('enderio:item_endergy_conduit', 10), item('solarflux:solar_panel_8'), item('solarflux:solar_panel_8'))
 	.output(item('solarflux:solar_panel_wyvern') * 2)
-	.energy(838860000)
-	.tierWyvern()
+	.energy(850_000_000).tierWyvern()
 	.register()
 
 // Reactor Core
@@ -54,8 +49,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('extendedcrafting:material', 13))
 	.input(metaitem('nomilabs:blockAwakenedDraconium'), metaitem('nomilabs:blockAwakenedDraconium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), item('nomilabs:stabilizedeinsteinium'), item('nomilabs:stabilizedeinsteinium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), metaitem('nomilabs:blockAwakenedDraconium'), metaitem('nomilabs:blockAwakenedDraconium'))
 	.output(item('draconicevolution:reactor_core'))
-	.energy(2600000000)
-	.tierDraconic()
+	.energy(2_500_000_000).tierDraconic()
 	.register()
 
 // Chaotic Fusion Crafting Injector
@@ -64,8 +58,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:crafting_injector', 2))
 	.input(item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'))
 	.output(item('draconicevolution:crafting_injector', 3))
-	.energy(3000000000)
-	.tierDraconic()
+	.energy(3_000_000_000).tierDraconic()
 	.register()
 
 // Draconic Fusion Crafting Injector
@@ -74,8 +67,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:crafting_injector', 1))
 	.input(item('minecraft:nether_star'), item('minecraft:dragon_egg'), item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'), item('minecraft:dragon_egg'), item('minecraft:nether_star'))
 	.output(item('draconicevolution:crafting_injector', 2))
-	.energy(1000000000)
-	.tierWyvern()
+	.energy(1_000_000_000).tierWyvern()
 	.register()
 
 // Energy Core Stabilizer
@@ -84,8 +76,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:particle_generator'))
 	.input(item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2), item('actuallyadditions:block_crystal_empowered', 2))
 	.output(item('draconicevolution:particle_generator', 2))
-	.energy(40000000)
-	.tierWyvern()
+	.energy(40_000_000).tierWyvern()
 	.register()
 
 // Reactor Stabilizer
@@ -94,8 +85,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:reactor_part'))
 	.input(item('draconicevolution:reactor_part', 4), item('draconicevolution:reactor_part', 3), item('draconicevolution:draconic_energy_core'), item('draconicevolution:draconic_energy_core'), item('draconicevolution:awakened_core'), item('draconicevolution:awakened_core'), item('draconicevolution:awakened_core'), item('draconicevolution:awakened_core'))
 	.output(item('draconicevolution:reactor_component'))
-	.energy(7040000000)
-	.tierChaotic()
+	.energy(7_000_000_000).tierChaotic()
 	.register()
 
 // Draconium Infused Obisidan
@@ -104,8 +94,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('enderio:block_reinforced_obsidian'))
 	.input(item('extrautils2:compressedcobblestone', 3), metaitem('nomilabs:blockDarkSteel'), metaitem('nomilabs:dustDraconium'), metaitem('nomilabs:dustDraconium'), item('thermalfoundation:material', 1024), item('thermalfoundation:material', 1024), item('armorplus:compressed_obsidian'), item('armorplus:compressed_obsidian'), item('armorplus:lava_crystal', 1), item('armorplus:lava_crystal', 1))
 	.output(item('draconicevolution:infused_obsidian'))
-	.energy(10485700)
-	.tierNormal()
+	.energy(10_500_000).tierNormal()
 	.register()
 
 // Draconic Energy Core
@@ -114,8 +103,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:wyvern_energy_core'))
 	.input(metaitem('nomilabs:ingotAwakenedDraconium'), metaitem('nomilabs:ingotAwakenedDraconium'), item('draconicevolution:awakened_core'), item('draconicevolution:awakened_core'), metaitem('energy.module'), metaitem('energy.module'), item('actuallyadditions:block_crystal_empowered'), item('actuallyadditions:block_crystal_empowered'), metaitem('nomilabs:ingotAwakenedDraconium'), metaitem('nomilabs:ingotAwakenedDraconium'))
 	.output(item('draconicevolution:draconic_energy_core'))
-	.energy(41943000)
-	.tierDraconic()
+	.energy(42_000_000).tierDraconic()
 	.register()
 
 // Awakened Draconium Blocks
@@ -124,8 +112,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(metaitem('nomilabs:blockDraconium') * 5)
 	.input(item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'), item('draconicevolution:dragon_heart'), item('draconicevolution:dragon_heart'), item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'))
 	.output(metaitem('nomilabs:blockAwakenedDraconium') * 5)
-	.energy(4000000000)
-	.tierWyvern()
+	.energy(4_000_000_000).tierWyvern()
 	.register()
 
 // Awakened Core
@@ -134,8 +121,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('minecraft:nether_star'))
 	.input(item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'), metaitem('nomilabs:blockAwakenedDraconium'), metaitem('nomilabs:blockAwakenedDraconium'), item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'))
 	.output(item('draconicevolution:awakened_core'))
-	.energy(500000000)
-	.tierWyvern()
+	.energy(500_000_000).tierWyvern()
 	.register()
 
 // Chaotic Core
@@ -144,8 +130,7 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(metaitem('gravistar'))
 	.input(item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), item('extendedcrafting:material', 32), item('extendedcrafting:material', 32), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'))
 	.output(item('draconicevolution:chaotic_core'))
-	.energy(3000000000)
-	.tierChaotic()
+	.energy(3_000_000_000).tierChaotic()
 	.register()
 
 // Advanced Disolcator
@@ -154,17 +139,19 @@ mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('draconicevolution:dislocator'))
 	.input(item('minecraft:ender_pearl'), metaitem('nomilabs:ingotDraconium'), item('minecraft:ender_pearl'), metaitem('nomilabs:ingotDraconium'), item('minecraft:ender_pearl'), metaitem('nomilabs:ingotDraconium'), item('minecraft:dragon_egg'), metaitem('nomilabs:ingotDraconium'))
 	.output(item('draconicevolution:dislocator_advanced'))
-	.energy(10000000)
-	.tierDraconic()
+	.energy(10_000_000).tierDraconic()
+	.register()
 
-// Packaged Draconic Recipes
+/* Packaged Draconic Recipes */
+
 // Fusion Package Crafter
 removeDraconicFusionRecipe(item('draconicevolution:fusion_crafting_core'), item('packageddraconic:fusion_crafter'))
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(item('draconicevolution:fusion_crafting_core'), item('extendedcrafting:interface') * 4, item('packagedauto:me_package_component') * 4, item('extendedcrafting:material', 12) * 4, metaitem('field.generator.iv'), metaitem('wireFineRuridit') * 64)
 	.fluidInputs(fluid('soldering_alloy') * 576)
 	.outputs(item('packageddraconic:fusion_crafter'))
-	.duration(400).EUt(VA[LuV]).buildAndRegister();
+	.duration(400).EUt(VA[LuV])
+	.buildAndRegister();
 
 // Marked Fusion Pedestals
 crafting.remove('packageddraconic:marked_basic_injector')
@@ -175,50 +162,49 @@ crafting.remove('packageddraconic:marked_chaotic_injector')
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(item('draconicevolution:crafting_injector'), item('extendedcrafting:material', 19), metaitem('sensor.iv'), ore('gearDraconium'))
 	.outputs(item('packageddraconic:marked_basic_injector'))
-	.duration(100).EUt(VA[IV]).buildAndRegister()
+	.duration(100).EUt(VA[IV])
+	.buildAndRegister()
 
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(item('draconicevolution:crafting_injector', 1), item('extendedcrafting:material', 19), metaitem('sensor.iv'), ore('gearDraconium'))
 	.outputs(item('packageddraconic:marked_wyvern_injector'))
-	.duration(100).EUt(VA[IV]).buildAndRegister()
+	.duration(100).EUt(VA[IV])
+	.buildAndRegister()
 
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(item('draconicevolution:crafting_injector', 2), item('extendedcrafting:material', 19), metaitem('sensor.iv'), ore('gearDraconium'))
 	.outputs(item('packageddraconic:marked_draconic_injector'))
-	.duration(100).EUt(VA[IV]).buildAndRegister()
+	.duration(100).EUt(VA[IV])
+	.buildAndRegister()
 
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(item('draconicevolution:crafting_injector', 3), item('extendedcrafting:material', 19), metaitem('sensor.iv'), ore('gearDraconium'))
 	.outputs(item('packageddraconic:marked_chaotic_injector'))
-	.duration(100).EUt(VA[IV]).buildAndRegister()
+	.duration(100).EUt(VA[IV])
+	.buildAndRegister()
 
 mods.draconicevolution.fusion.recipeBuilder()
 	.catalyst(item('packageddraconic:marked_basic_injector'))
 	.input(item('draconicevolution:wyvern_core'), item('draconicevolution:draconic_core'), item('minecraft:nether_star'), item('minecraft:nether_star'), item('draconicevolution:draconic_core'), ore('blockDraconium'), item('minecraft:nether_star'), item('minecraft:nether_star'))
 	.output(item('packageddraconic:marked_wyvern_injector'))
-	.energy(256000)
-	.tierNormal()
+	.energy(256_000).tierNormal()
 	.register()
 
 mods.draconicevolution.fusion.recipeBuilder()
-		.catalyst(item('packageddraconic:marked_wyvern_injector'))
-		.input(item('minecraft:nether_star'), item('minecraft:dragon_egg'), item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'), item('minecraft:dragon_egg'), item('minecraft:nether_star'))
-		.output(item('packageddraconic:marked_draconic_injector'))
-		.energy(1000000000)
-		.tierWyvern()
-		.register()
+	.catalyst(item('packageddraconic:marked_wyvern_injector'))
+	.input(item('minecraft:nether_star'), item('minecraft:dragon_egg'), item('draconicevolution:wyvern_core'), item('draconicevolution:wyvern_core'), item('minecraft:dragon_egg'), item('minecraft:nether_star'))
+	.output(item('packageddraconic:marked_draconic_injector'))
+	.energy(1_000_000_000).tierWyvern()
+	.register()
 
 mods.draconicevolution.fusion.recipeBuilder()
-		.catalyst(item('packageddraconic:marked_draconic_injector'))
-		.input(item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'))
-		.output(item('packageddraconic:marked_chaotic_injector'))
-		.energy(3000000000)
-		.tierDraconic()
-		.register()
+	.catalyst(item('packageddraconic:marked_draconic_injector'))
+	.input(item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('nomilabs:blockCrystalMatrix'), metaitem('ingotNeutronium'), metaitem('ingotNeutronium'), item('draconicevolution:chaos_shard'), item('draconicevolution:chaos_shard'))
+	.output(item('packageddraconic:marked_chaotic_injector'))
+	.energy(3_000_000_000).tierDraconic()
+	.register()
 
 crafting.addShapeless(item('draconicevolution:crafting_injector'), [item('packageddraconic:marked_basic_injector')])
 crafting.addShapeless(item('draconicevolution:crafting_injector', 1), [item('packageddraconic:marked_wyvern_injector')])
 crafting.addShapeless(item('draconicevolution:crafting_injector', 2), [item('packageddraconic:marked_draconic_injector')])
 crafting.addShapeless(item('draconicevolution:crafting_injector', 3), [item('packageddraconic:marked_chaotic_injector')])
-
-


### PR DESCRIPTION
The script forgot to call `.register()` on the advanced discolator recipe. This PR simply fixes that, as well as:
- Formatting the Draconic Fusion Script
- Slightly Normalizing Energy Costs for Draconic Fusion Recipes