### PR TITLE
Fix Edge Case Corruption on Worlds Loaded in 1.7-beta-5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5544891,
+      "fileID": 5545493,
       "required": true
     },
     {

--- a/tools/templates/nomilabs-version.cfg
+++ b/tools/templates/nomilabs-version.cfg
@@ -4,6 +4,15 @@ general {
     # Formatted Version of the Modpack. Currently just used as a Substitution in the Window Title Override.
     # [default: v1.0.0]
     S:formattedVersion={{version}}
+
+    # Manual Fix Version. Increment this to have Data Fixers be POTENTIALLY applied.
+    # Note that if a chunk or inventory is loaded on the same fix version multiple times, it will only be fixed the first time.
+    # Note that no warning will be displayed before game load.
+    # The data fix version itself will be this config + the Labs internal fix version.
+    # [default: 0]
+    # Min: 0
+    # Max: 2147483647
+    I:manualFixVersion=1
 }
 
 


### PR DESCRIPTION
This PR forces a re-application of Data Fixers, in order to remap AE2 Stuff Pattern Encoders on chunks that have already been loaded in 1.7-beta-5.