### PR TITLE
Update Universal Tweaks to v1.12.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -686,7 +686,7 @@
     },
     {
       "projectID": 705000,
-      "fileID": 5350889,
+      "fileID": 5529764,
       "required": true
     },
     {

--- a/overrides/config/Universal Tweaks - Bugfixes.cfg
+++ b/overrides/config/Universal Tweaks - Bugfixes.cfg
@@ -116,6 +116,10 @@ general {
         # Changes UUIDs of loaded entities in case their UUIDs are already assigned (and removes log spam)
         B:"Entity UUID"=true
 
+        # Fixes the player model occasionally disappearing when flying with elytra in a straight line in third-person mode
+        # Incompatible with OpenModsLib
+        B:"Fixes Invisible Player when Flying with Elytra"=true
+
         # Modifies falling logic of horses, listening to LivingFallEvent and taking jump boost into account
         B:"Horse Falling"=true
 

--- a/overrides/config/Universal Tweaks - Mod Integration.cfg
+++ b/overrides/config/Universal Tweaks - Mod Integration.cfg
@@ -110,6 +110,10 @@ general {
     }
 
     "extra utilities 2" {
+        # When near some inventories, the Radar feature (find in nearby inventories) will entirely break
+        # this catches the AbstractMethodException thrown, allowing other nearby inventories to be searched
+        B:"Catch Radar Exception"=true
+
         # Fixes the Creative Mill Generator not respecting the Creative Block Breaking config
         B:"Creative Mill Harvestability"=true
 
@@ -330,6 +334,12 @@ general {
 
             # Adds an impact sound to the rift focus effect
             B:"[12] Rift: Impact Sound"=true
+
+            # Overhauls the exchange focus effect cast sound
+            B:"[13] Exchange: Cast Sound Revamp"=true
+
+            # Adds an impact sound to the exchange focus effect
+            B:"[14] Exchange: Impact Sound"=true
         }
 
         "focus mediums" {
@@ -392,6 +402,9 @@ general {
 
         # Caches all ore dictionary smelting recipes to speed up game loading
         B:"Ore Dictionary Cache"=true
+
+        # Fixes server world being leaked to various particles
+        B:"Particle Fixes"=true
 
         # Despawns unbreakable projectiles faster to improve framerates
         B:"Projectile Despawning"=true
@@ -479,6 +492,37 @@ general {
     "rftools dimensions" {
         # Fixes a bug where joining a world or server with any RFTools Dimension registered would disallow entering another world without that dimension until restarting
         B:"Fully Unregister Dimensions"=true
+    }
+
+    "codechicken lib" {
+        # Fixes network ByteBuf leaks from PacketCustom
+        B:"Packet Leak Fix"=true
+    }
+
+    "ender storage" {
+        # Fixes storage frequencies being tracked multiple times
+        B:"Fix Frequency Tracking"=true
+    }
+
+    openblocks {
+        # Fixes the Last Stand enchantment triggering too early on pre-mitigation damage (before enchants, potions, etc)
+        # instead of on post-mitigation damage.
+        B:"Last Stand Trigger Fix"=true
+    }
+
+    opencomputers {
+        # Fixes network ByteBuf leaks from PacketHandler
+        B:"Packet Leak Fix"=true
+    }
+
+    "requious frakto" {
+        # Fixes server world being leaked to various particles
+        B:"Particle Fixes"=true
+    }
+
+    steamworld {
+        # Fixes a Stack Overflow crash when entering the Sky of Old Dimension
+        B:"Sky of Old Dimension Fix"=true
     }
 
 }

--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -45,8 +45,17 @@ general {
         # Allows the player to jump over fences and walls
         B:"Fence/Wall Jump"=true
 
+        # Causes Barrier Particles to always be displayed to players in Creative mode
+        B:"Improve Barrier Particle Display"=false
+
         # Allows the creation of grass paths everywhere (beneath fence gates, trapdoors, ...)
         B:"Lenient Paths"=true
+
+        # Controls if the observer activates itself on the first tick when it is placed
+        B:"Prevent Observer Activating on Placement"=false
+
+        # Controls if the End Portal renders its texture on the bottom face
+        B:"Render End Portal Bottom"=true
 
         # Determines how tall sugar cane can grow
         I:"Sugar Cane Size"=3
@@ -207,6 +216,12 @@ general {
         # Lets baby zombies burn in daylight as in Minecraft 1.13+
         B:"Burning Baby Zombies"=true
 
+        # Lets skeletons burn in daylight
+        B:"Burning Skeletons"=true
+
+        # Lets zombies burn in daylight
+        B:"Burning Zombies"=true
+
         # Sets the chance for creepers to spawn charged
         # Min: 0.0
         # Max: 1.0
@@ -234,6 +249,9 @@ general {
 
         # Lets husks and strays spawn underground like regular zombies and skeletons
         B:"Husk & Stray Spawning"=true
+
+        # Replaces vanilla Minecarts dropping a Minecart and the contained item, and instead drop the combined item
+        B:"Minecart Drops Itself"=false
 
         # Mobs carrying picked up items will drop their equipment and despawn properly
         B:"Mob Despawn Improvement"=true
@@ -264,6 +282,9 @@ general {
 
         # Summoned vexes will also die when their summoner is killed
         B:"Soulbound Vexes"=true
+
+        # When viewing in third person, don't stop the camera on non-solid blocks
+        B:"Third Person Ignores Non-solid Blocks"=false
 
         # Allows creating Iron Golems with non-air blocks in the bottom corners of the structure
         B:"Weaken Golem Structure Requirements"=false
@@ -595,6 +616,9 @@ general {
         S:"Custom Use Duration" <
          >
 
+        # Causes Glass Bottles to consume the source block of water
+        B:"Glass Bottle Consumes Water Source"=false
+
         # Prevents placing of liquid source blocks in the world
         B:"Hardcore Buckets"=false
 
@@ -603,6 +627,12 @@ general {
 
         # Disables dragon's breath from being a container item and leaving off empty bottles when a stack is brewed with
         B:"No Leftover Breath Bottles"=true
+
+        # Prevents using Mob Spawner Eggs to change what a Spawner is spawning
+        B:"Prevent Mob Eggs from Changing Spawners"=false
+
+        # Prevents placing of liquid source blocks overriding portal blocks
+        B:"Prevent Placing Buckets in Portals"=false
 
         # Enables one-time ignition of entities by hitting them with a torch
         B:"Super Hot Torch"=false
@@ -755,10 +785,14 @@ general {
         # Always displays the actual potion duration instead of `**:**`
         B:"Accurate Potion Duration"=true
 
+        # Always returns the player to the main menu when quitting the game
+        B:"Always Return to Main Menu"=false
+
         # Displays the ping in milliseconds of players when viewing the server list
         B:"Better Ping Display"=true
 
         # Enables clicking of `/seed` world seed in chat to copy to clipboard
+        # Required on server AND client
         B:"Copy World Seed"=true
 
         # Restores feature to tilt the camera when damaged
@@ -773,7 +807,16 @@ general {
         S:"Default Difficulty"=PEACEFUL
 
         # Prevents the advancement system from loading entirely
-        B:"Disable Advancements"=true
+        B:"Disable Advancements"=false
+
+        # Disables the glint overlay on enchantment books
+        B:"Disable Glint Overlay on Enchantment Books"=false
+
+        # Disables the glint overlay on potions
+        B:"Disable Glint Overlay on Potions"=false
+
+        # Disables using the scroll wheel to change hotbar slots wrapping
+        B:"Disable Hotbar Scroll Wrapping"=false
 
         # Disables the narrator functionality entirely
         B:"Disable Narrator"=false
@@ -820,13 +863,18 @@ general {
         # -4 for vanilla default
         I:"Overlay Message Height"=-4
 
+        # Limits particles to a set amount. Should not be set too low, as it will cause particles to appear for a single tick before vanishing
+        # Vanilla default is 16384
+        # Less than or equal to 0 is set to the default
+        I:"Particle Limit"=-1
+
         # Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present
         B:"Prevent Keybinds from Overflowing Screen"=true
 
         # Removes the 3D Anaglyph button from the video settings menu
         B:"Remove 3D Anaglyph Button"=true
 
-        # Removes the redundant Minecraft Realms button from the main menu
+        # Removes the redundant Minecraft Realms button from the main menu and silences notifications
         # Incompatible with RandomPatches
         B:"Remove Realms Button"=true
 
@@ -849,6 +897,12 @@ general {
 
         # Adds a button to the pause menu to toggle cheats
         B:"Toggle Cheats Button"=true
+
+        # Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently
+        B:"Use Separate Dismount Key"=false
+
+        # Allows using a custom Narrator key, instead of being stuck with CTRL+B
+        B:"Use Separate Narrator Key"=false
 
         # Sets the maximum experience level players can reach
         # 0 to effectively disable gaining of experience
@@ -1082,6 +1136,35 @@ general {
             B:"[3] Compact Messages"=true
         }
 
+        advancements {
+            # Enables Advancement GUI Tweaks
+            B:"[01] Advancements Toggle"=false
+
+            # Enables the Vertical and Horizontal Margin settings
+            B:"[02] Size Toggle"=true
+
+            # Sets the minimum Vertical Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale
+            I:"[03] Vertical Margin"=50
+
+            # Sets the minimum Horizontal Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale
+            I:"[04] Horizontal Margin"=50
+
+            # Move the Arrow Buttons visible to change focused advancement page from above the advancement box to in the empty top corners, preventing them from going offscreen and being unusable on most vertical margin settings
+            B:"[05] Move Arrow Buttons"=true
+
+            # Hides the page number header, as it will go offscreen and be unusable on most vertical margin settings, and is rarely needed due to the increased page size
+            B:"[06] Hide Page Header"=false
+
+            # Hides page switching buttons when at the maximum/minimum page count
+            B:"[07] Hide Invalid Arrow Buttons"=true
+
+            # Disables the background fading when hovering over an advancement
+            B:"[08] Disable Background Fade on Hover"=true
+
+            # Makes the focused Advancement Tab Title be added to the header, which otherwise is just 'Advancements' for every tab
+            B:"[09] Add Advancement Tab Title to Header"=true
+        }
+
     }
 
     performance {
@@ -1116,14 +1199,21 @@ general {
         # Fixes slow background startup edge case caused by checking tooltips during the loading process
         B:"Faster Background Startup"=true
 
+        # Improves the speed of switching languages in the Language GUI
+        B:"Improve Language Switching Speed"=true
+
+        # Improves the speed of connecting to servers by setting the InetAddress host name to the IP in situations
+        # where it can be represented as the IP address, preventing getHostFromNameService from being to be run
+        B:"Improve Server Connection Speed"=true
+
         # Silences advancement errors
-        B:"Mute Advancement Errors"=false
+        B:"Mute Advancement Errors"=true
 
         # Silences ore dictionary errors
         B:"Mute Ore Dictionary Errors"=false
 
         # Silences texture map errors
-        B:"Mute Texture Map Errors"=false
+        B:"Mute Texture Map Errors"=true
 
         # Disables mob pathfinding from loading new/unloaded chunks when building chunk caches
         B:"No Pathfinding Chunk Loading"=true
@@ -1165,6 +1255,7 @@ general {
 
     world {
         # Sets the default height of the overworld's sea level
+        # Supported world types: Default, Biomes O' Plenty
         # Vanilla default is 63
         I:"Sea Level"=63
 


### PR DESCRIPTION
This PR updates Universal Tweaks to v1.12.0. Other changes are:
- Re-enabling Advancements (so that GT Capes can be unlocked)
- Muting Advancement Errors
- Muting Texture Map Errors