### PR TITLE
Add Debug Log Output to Dedicated Servers

### DIFF
--- a/serverfiles/log4j2_112-116.xml
+++ b/serverfiles/log4j2_112-116.xml
@@ -2,12 +2,23 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="SysOut" target="SYSTEM_OUT">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
         </Console>
         <Queue name="ServerGuiConsole">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg{nolookups}%n" />
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <OnStartupTriggeringPolicy />
+            </Policies>
+        </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/%d{yyyy-MM-dd}-%i-debug.log.gz">
+            <!-- No Threshold Filter Here -->
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
             <Policies>
                 <TimeBasedTriggeringPolicy />
@@ -16,13 +27,14 @@
         </RollingRandomAccessFile>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="DEBUG">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
             </filters>
             <AppenderRef ref="SysOut"/>
             <AppenderRef ref="File"/>
             <AppenderRef ref="ServerGuiConsole"/>
+            <AppenderRef ref="DebugFile"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
This PR adds a `debug.log` file output to server logs, containing all levels of logs (including DEBUG).

This helps with debugging issues on dedicated servers greatly.