### PR TITLE
Primal Mana -> Mana Dust Solidifier Recipe

### DIFF
--- a/overrides/scripts/extractor_solidifier.zs
+++ b/overrides/scripts/extractor_solidifier.zs
@@ -36,6 +36,12 @@ fluid_extractor.recipeBuilder()
     .fluidOutputs([<liquid:mana> * 250])
     .duration(40).EUt(30).buildAndRegister();
 
+solidifier.recipeBuilder()
+    .fluidInputs([<liquid:mana> * 250])
+    .notConsumable(<metaitem:shape.mold.ball>)
+    .outputs([<thermalfoundation:material:1028>])
+    .duration(40).EUt(30).buildAndRegister();
+
 fluid_extractor.recipeBuilder()
     .inputs([<thermalfoundation:coin:1>])
     .fluidOutputs([<liquid:gold> * 48])


### PR DESCRIPTION
This PR adds a solidifier recipe from Primal Mana to Mana Dust, essentially a QoL, so players can revert their extractions into Primal Mana.