### PR TITLE
Add Alternate and Balance Implosion Recipes for Omnium

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/lategame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/lategame.groovy
@@ -1,7 +1,28 @@
 import com.nomiceu.nomilabs.util.LabsModeHelper
+import gregtech.api.recipes.builders.ImplosionRecipeBuilder
+import net.minecraft.item.ItemStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
+
+// Omnium Implosion Compressor Recipes
+ImplosionRecipeBuilder builder = mods.gregtech.implosion_compressor.recipeBuilder()
+	.inputs(item('extendedcrafting:singularity_ultimate'))
+	.outputs(item('extendedcrafting:material:33'))
+	.chancedOutput(item('gregtech:meta_dust', 275), 2500, 0)
+	.duration(20).EUt(VA[LV])
+
+// TNT
+builder.copy()
+	.explosivesAmount(8)
+	.buildAndRegister()
+
+// Other Explosives
+for (ItemStack explosive : [item('gregtech:powderbarrel') * 16, metaitem('dynamite') * 4, item('gregtech:itnt') * 2]) {
+	builder.copy()
+		.explosivesType(explosive)
+		.buildAndRegister()
+}
 
 if (LabsModeHelper.normal) {
 	// Assembly Control Casing (Change from Output 2 to Output 4)

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -307,15 +307,6 @@ electrolyzer.recipeBuilder()
 	.fluidOutputs(<liquid:chlorine> * 2000, <liquid:hydrogen> * 4000)
 	.duration(576).EUt(60).buildAndRegister();
 
-
-
-//Omnium
-implosion_compressor.recipeBuilder()
-	.inputs([<extendedcrafting:singularity_ultimate>])
-	.outputs(<extendedcrafting:material:33>)
-	.property("explosives", <metaitem:dynamite> * 8)
-	.duration(20).EUt(30).buildAndRegister();
-
 //Add Decomposition Recipe for Polyphenylene Sulfide
 electrolyzer.recipeBuilder()
 	.fluidInputs(<liquid:polyphenylene_sulfide> * 11000)

--- a/overrides/scripts/extendedcrafting.zs
+++ b/overrides/scripts/extendedcrafting.zs
@@ -236,14 +236,6 @@ makeExtremeRecipe7(<extendedcrafting:table_ultimate>,
       E : <minecraft:emerald_block>,
       T : <extendedcrafting:table_elite> });
 
-implosion.recipeBuilder()
-    .inputs([<extendedcrafting:singularity_ultimate>])
-    .property("explosives", 1)
-    .outputs(<extendedcrafting:material:33>)
-    .duration(20).EUt(30).buildAndRegister();
-
-
-
 recipes.remove(<minecraft:end_crystal>);
 // End Crystal * 1
 <recipemap:assembler>.findRecipe(16, [<minecraft:ghast_tear:0>, <minecraft:ender_eye:0>], [<liquid:glass> * 1008]).remove();


### PR DESCRIPTION
This PR adds alternate implosion compressor recipes for omnium, adding ITnT and Powderbarrel.

This PR also makes the omnium recipe more like other normal implosion compressor recipes. It makes the following changes:
- Now has a chanced output of dark ash (like other recipes)
- Requires 8 TNT (from 1) (double normal recipes)
- Requires 4 Dynamite (from 8) (double normal recipes)

Powderbarrel and ITnT costs 16 and 2 respectively, also double their cost in normal recipes.