### PR TITLE
Fix Thermal Cycle Item Mode Keybind

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
@@ -20,8 +20,6 @@ addOverride('key.craftpresence.config_keycode.name', Keyboard.KEY_NONE)
 
 addOverride('Open Rocket GUI', KeyModifier.CONTROL, Keyboard.KEY_C)
 
-addOverride('key.cofh.multimode', Keyboard.KEY_NONE)
-
 addOverride('key.craftingtweaks.compressAll', Keyboard.KEY_NONE)
 addOverride('key.craftingtweaks.compressOne', Keyboard.KEY_NONE)
 addOverride('key.craftingtweaks.compressStack', Keyboard.KEY_NONE)


### PR DESCRIPTION
This PR simply re-enables the `Cycle Item Mode` keybind for Thermal Expansion items by default. Although the default key for this keybind, 'V', conflicts with another keybind, the other keybind is simply an item mode cycler for GregTech items, meaning the conflict will not affect gameplay.