### PR TITLE
Fix NC Fluids in JEI

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluids.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluids.groovy
@@ -82,6 +82,25 @@ fixItemFluidTooltip(item('actuallyadditions:block_refined_canola_oil'), fluid('r
 fixItemFluidTooltip(item('actuallyadditions:block_crystal_oil'), fluid('crystaloil'))
 fixItemFluidTooltip(item('actuallyadditions:block_empowered_oil'), fluid('empoweredoil'))
 
+/* NuclearCraft */
+
+// Fixes (With Tooltip)
+fixItemFluidTooltip(item('nuclearcraft:fluid_chocolate_liquor'), fluid('chocolate_liquor'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_cocoa_butter'), fluid('cocoa_butter'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_unsweetened_chocolate'), fluid('unsweetened_chocolate'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_dark_chocolate'), fluid('dark_chocolate'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_milk_chocolate'), fluid('milk_chocolate'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_sugar'), fluid('sugar'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_gelatin'), fluid('gelatin'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_hydrated_gelatin'), fluid('hydrated_gelatin'))
+fixItemFluidTooltip(item('nuclearcraft:fluid_marshmallow'), fluid('marshmallow'))
+
+// Tooltip Additions
+addFluidTooltip(fluid('quartz'))
+addFluidTooltip(fluid('lapis'))
+addFluidTooltip(fluid('diamond'))
+addFluidTooltip(fluid('emerald'))
+
 /* Util Functions */
 
 /**


### PR DESCRIPTION
This PR simply fixes NuclearCraft fluids' displays in JEI (appearing as an 'item' instead of a 'fluid'), as well as adding GregTech fluid tooltips to all (visible) NuclearCraft fluids.

This procedure was done for other fluids of other mods in https://github.com/Nomi-CEu/Nomi-CEu/pull/796, but NuclearCraft and its fluids were missed.