### PR TITLE
Fix Duplicate Prospector Tooltip + Cleanup

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
@@ -46,11 +46,11 @@ for (ItemStack stack : items) {
 			])
 			addRecipeOutputTooltip(recipeStack, resource(recipeName),
 				ItemMeta.compare(tool, recipeStack) ?
-					translatable("tooltip.hand_framing.tool") :
-					translatable("tooltip.hand_framing.drawer"),
-				translatable("tooltip.hand_framing.top_left"),
-				translatable("tooltip.hand_framing.top_right"),
-				translatable("tooltip.hand_framing.bottom_left"))
+					translatable("nomiceu.tooltip.labs.hand_framing.tool") :
+					translatable("nomiceu.tooltip.labs.hand_framing.drawer"),
+				translatable("nomiceu.tooltip.labs.hand_framing.top_left"),
+				translatable("nomiceu.tooltip.labs.hand_framing.top_right"),
+				translatable("nomiceu.tooltip.labs.hand_framing.bottom_left"))
 		}
 	}
 }

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -242,15 +242,6 @@ addTooltip(metaitem('cover.facade'), [
 	translatable('nomiceu.tooltip.gregtech.facade.2'),
 ])
 
-/* Extended Crafting */
-
-// Omnium Trimmed Black Steel
-clearTooltip(item('extendedcrafting:trimmed', 5))
-addTooltip(item('extendedcrafting:trimmed', 5), [
-	translatable('nomiceu.tooltip.extendedcrafting.black_steel.omnium.1'),
-	translatable('nomiceu.tooltip.extendedcrafting.black_steel.omnium.2'),
-])
-
 /* Ender IO */
 
 // Glasses

--- a/overrides/resources/extendedcrafting/lang/en_us.lang
+++ b/overrides/resources/extendedcrafting/lang/en_us.lang
@@ -33,3 +33,6 @@ tile.ec.storage_ender_star.name=Block of Endest Stars
 # line 75-76
 item.ec.material_ender_star.name=Endest Star
 item.ec.material_ender_star_nugget.name=Endest Star Nugget
+
+# Ultimate Trimmed -> Omnium Trimmed
+tooltip.ec.trimmed_ultimate=Omnium Trimmed

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -1,3 +1,4 @@
+# No Nether Portals
 nomifactory.nonetherportals=Nether portals are disabled in §5Nomi-CEu§r. Follow the quest book to unlock §6Nether Cakes§r!
 
 # Tooltips
@@ -77,16 +78,19 @@ nomiceu.tooltip.gregtech.prospector.4=Use JEI to check the potential vein depth.
 nomiceu.tooltip.gregtech.facade.1=§3GTCEu facades can be made from most non-tile-entities.§r
 nomiceu.tooltip.gregtech.facade.2=§3They craft into different amounts based on the metal used!§r
 
-# Extended Crafting
-nomiceu.tooltip.extendedcrafting.black_steel.omnium.1=Block of Black Steel
-nomiceu.tooltip.extendedcrafting.black_steel.omnium.2=§7Omnium Trimmed§r
-
 # Ender IO
 tooltip.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r
 tooltip.eio_glass.dye=Can be §bDyed§r!
 
 # Project Red
 nomiceu.tooltip.projectred.wire=§eFor use with ProjectRed.§r
+
+# Nomi Labs
+nomiceu.tooltip.labs.hand_framing.tool=§5Frame your Hand Framing Tool by Hand!§r
+nomiceu.tooltip.labs.hand_framing.drawer=§5Frame your Drawers by Hand!§r
+nomiceu.tooltip.labs.hand_framing.top_left=§5Top Left: §oSide§r
+nomiceu.tooltip.labs.hand_framing.top_right=§5Top Right: §oTrim§r
+nomiceu.tooltip.labs.hand_framing.bottom_left=§5Bottom Left: §oFront§r
 
 # XTones
 nomiceu.tooltip.xtones.lamp=§eRequires a redstone signal to light.§r

--- a/overrides/resources/nomiceu/lang/en_us.lang
+++ b/overrides/resources/nomiceu/lang/en_us.lang
@@ -1,5 +1,0 @@
-tooltip.hand_framing.tool=§5Frame your Hand Framing Tool by Hand!§r
-tooltip.hand_framing.drawer=§5Frame your Drawers by Hand!§r
-tooltip.hand_framing.top_left=§5Top Left: §oSide§r
-tooltip.hand_framing.top_right=§5Top Right: §oTrim§r
-tooltip.hand_framing.bottom_left=§5Bottom Left: §oFront§r

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -395,7 +395,3 @@ macerator.recipeBuilder()
     .duration(236)
     .EUt(8)
     .buildAndRegister();*/
-
-<gregtech:meta_item_1:466>.addTooltip(format.yellow("Grid squares correspond to 1 chunk, up is north\nClick a resource name in sidebar to highlight only it\nUse JEI to check potential vein depth"));
-<gregtech:meta_item_1:467>.addTooltip(format.yellow("Grid squares correspond to 1 chunk, up is north\nClick a resource name in sidebar to highlight only it\nUse JEI to check potential vein depth"));
-<gregtech:meta_item_1:468>.addTooltip(format.yellow("Grid squares correspond to 1 chunk, up is north\nClick a resource name in sidebar to highlight only it\nUse JEI to check potential vein depth"));


### PR DESCRIPTION
This PR fixes duplicate prospector tooltips, of which were caused by the original implementation of the tooltips not being removed when the new groovy implementation was added.

This PR also cleans up the tooltip changes for Extended Crafting's Block of Black Steel, Omnium Trimmed, by overriding the lang key for the tooltip itself, instead of clearing all tooltips.

Finally, this PR also moves the lang keys located in `nomiceu/lang/en_us.lang` to the current location for all tooltip keys (`modpack/lang/en_us.lang`), changing the lang keys located there to the new formatting as well.