### PR TITLE
Cleanup NuclearCraft JEI Removals

### DIFF
--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -56,18 +56,6 @@ for jeiCategory in jeiCategories {
 }
 
 function purgeFluidFromJEI(fluid as string) {
-    // gtce various metal cells
-    val containers = [<metaitem:large_fluid_cell.steel>,
-                      <metaitem:fluid_cell>,
-                      <metaitem:large_fluid_cell.tungstensteel>] as IItemStack[];
-
-    // remove from various GT containers
-    for container in containers {
-        mods.jei.JEI.removeAndHide(container.withTag({Fluid: {FluidName: fluid, Amount: 1000}}));
-    }
-
-    // Different tag schemas...
-//    mods.jei.JEI.removeAndHide(<ceramics:clay_bucket>.withTag({fluids: {FluidName: fluid, Amount: 1000}}));
     mods.jei.JEI.removeAndHide(<forge:bucketfilled>.withTag({FluidName: fluid, Amount: 1000}));
 }
 


### PR DESCRIPTION
This PR cleans up the JEI Removals for NuclearCraft Fluids, by having it not attempt to remove the fluid from GT Cells (which do not have a version in JEI containing each fluid, as opposed to GTCE).

This fixes most of the JEI Removal Errors that appear in the log on instance load and after `/gs reload`.