### PR TITLE
Make Naquadah Reactor 2 Recipe ZPM -> UV

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/assemblyLine.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Late-Game/assemblyLine.groovy
@@ -103,7 +103,7 @@ mods.gregtech.assembly_line.recipeBuilder()
 	.fluidInputs(fluid('soldering_alloy') * 1152, fluid('omnium') * 288)
 	.outputs(metaitem('nomilabs:naquadah_reactor_2'))
 	.stationResearch(b -> b.researchStack(metaitem('nomilabs:naquadah_reactor_1')).CWUt(64).EUt(VA[UV]))
-	.duration(1500).EUt(VA[ZPM])
+	.duration(1500).EUt(VA[UV])
 	.buildAndRegister()
 
 // Universal Navigator


### PR DESCRIPTION
This PR changes the Naquadah Reactor 2's Assembly Line recipe to be UV. This was for two reasons:
- The Circuit Requirement for the Naq Reactor 2 is UV
- The Research Recipe for the Naq Reactor 2 is UV
- Having it be UV adds a little scaling between the Naq Reactor 1 and Naq Reactor 2 Assembly Line Recipes, in terms of Energy Requirement

Note that this PR is based off `labs-0.8.0` at the moment, as it requires changes made by that branch. Once that PR is merged, this PR will be rebased to be based off `main`. For now, note that https://github.com/Nomi-CEu/Nomi-CEu/commit/aa435fd0e6e9cbc019bd835cfb97b53e80353130 is the only commit that matters.