### PR TITLE
Black Steel ABS Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
@@ -1,3 +1,8 @@
+import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
+import gregtech.api.recipes.RecipeBuilder
+import gregtech.api.recipes.ingredients.GTRecipeInput
+import net.minecraftforge.fluids.FluidStack
+
 import static gregtech.api.GTValues.*
 
 // Rhodium Plated Palladium -> Rhodium Plated Lumium-Palladium
@@ -15,14 +20,19 @@ material('rhodium_plated_palladium')
 // Can't use change composition to remove, as that is only performed at the end of running scripts, and if not removed, conflicts will occur.
 // TODO Make this use change composition when that accepts non-material Item Stacks
 
-// Remove ABS Recipes
-mods.gregtech.alloy_blast_smelter.removeByOutput(null, [fluid('black_steel')])
+// Change ABS Recipes
+mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('black_steel')])
+	.forEach { ChangeRecipeBuilder builder ->
+		builder.builder { RecipeBuilder recipe ->
+			recipe.clearInputs()
+				.inputs(metaitem('dustSteel') * 3, metaitem('dustBlackBronze') * 2, item('actuallyadditions:item_crystal', 3) * 2, item('extrautils2:ingredients', 4) * 2)
+		}.changeCircuitMeta { meta -> meta + 1 }
+		.changeEachFluidOutput { FluidStack fluid -> return fluid * (L * 9) }
+		.replaceAndRegister()
+	}
 
-// Remove Mixer Recipes
+/* Change Mixer Recipes */
 mods.gregtech.mixer.removeByOutput([metaitem('dustBlackSteel')], null)
-
-// Remove Decomp Recipe
-mods.gregtech.centrifuge.removeByInput([metaitem('dustBlackSteel')], null)
 
 // Normal Mixer Recipe
 mods.gregtech.mixer.recipeBuilder()
@@ -31,21 +41,20 @@ mods.gregtech.mixer.recipeBuilder()
 	.duration(200).EUt(VHA[LV])
 	.buildAndRegister()
 
-/* Black Steel Shortcut */
-// Normal recipe would be 50 ticks per recipe at HV overclock, plus 125 ticks for the Black Bronze step,
-// for a total of 375 ticks. This recipe is 5 batches at once, so is equivalent time but saves a step.
+// Shortcut Mixer Recipe
 mods.gregtech.mixer.recipeBuilder()
 	.inputs(metaitem('dustSteel') * 15, metaitem('dustCopper') * 6, metaitem('dustGold') * 2, metaitem('dustSilver') * 2, item('actuallyadditions:item_crystal', 3) * 10, item('extrautils2:ingredients', 4) * 10)
 	.outputs(metaitem('dustBlackSteel') * 45)
-	.duration(375).EUt(VHA[HV])
+	.duration(300).EUt(VHA[HV])
 	.buildAndRegister()
 
-// Decomp Recipe
-mods.gregtech.centrifuge.recipeBuilder()
-	.inputs(metaitem('dustBlackSteel') * 9)
-	.outputs(metaitem('dustSteel') * 3, metaitem('dustBlackBronze') * 2, item('actuallyadditions:item_crystal', 3) * 2, item('extrautils2:ingredients', 4) * 2)
-	.duration(480).EUt(VA[LV] * 2)
-	.buildAndRegister()
+// Change Decomp Recipe
+mods.gregtech.centrifuge.changeByInput([metaitem('dustBlackSteel')], null)
+	.changeEachInput { GTRecipeInput input -> input.copyWithAmount(9) }
+		.builder { RecipeBuilder recipe ->
+			recipe.clearOutputs()
+				.outputs(metaitem('dustSteel') * 3, metaitem('dustBlackBronze') * 2, item('actuallyadditions:item_crystal', 3) * 2, item('extrautils2:ingredients', 4) * 2)
+		}.replaceAndRegister()
 
 // Change Chem Formula
 material('black_steel')


### PR DESCRIPTION
This PR simply adds a Black Steel ABS recipe, which is the same as the original but with different inputs and fluid output amounts.

This PR also changes the shortcut Black Steel recipe to be 1.5x the duration of the normal recipe, instead of the previous 1.875x, following on from the original GT recipe.

Note that this PR is based off `labs-0.8.0` at the moment, as it requires changes made by that branch. Once that PR is merged, this PR will be rebased to be based off `main`. For now, note that https://github.com/Nomi-CEu/Nomi-CEu/commit/ae6f5684a5698545fe4dd71887bdc39b7f45acdb is the only commit that matters.