### PR TITLE
Fix Glowstone Decomposition Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
@@ -15,6 +15,13 @@ material('rhodium_plated_palladium')
 	.changeChemicalFormula()
 	.change()
 
+material('glowstone')
+	.changeComposition()
+	.setComponents([metaitem('dustGold'), metaitem('dustTricalciumPhosphate')])
+	.changeDecompositionRecipes()
+	.changeChemicalFormula()
+	.change()
+
 /* Black Steel */
 
 // Can't use change composition to remove, as that is only performed at the end of running scripts, and if not removed, conflicts will occur.


### PR DESCRIPTION
This PR fixes the glowstone decomposition recipe.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/834.

This PR has the side effect of moving glowstone's decomposition recipe to the electrolyser (from the centrifuge), as that is where GT calculates the new decomposition recipe should go.