### PR TITLE
Fix Edge Case Issues with PAs and Cleanrooms

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5586524,
+      "fileID": 5594636,
       "required": true
     },
     {


### PR DESCRIPTION
This PR fixes an issue where PAs would not run recipes in cleanrooms under very specific scenarios.

From https://github.com/Nomi-CEu/Nomi-CEu/issues/844:
> There are actually two issues here, both stemming from the same core issue. We have fixed both in Labs 0.8.3, and here are the reproduction steps.
> 
> For the issue listed above, where PAs would not work after world reload, the method found to > reproduce this issue was:
> 1. Make a Plascrete Floor
> 2. Build an Advanced PA **(Must Place Controller)**
> 3. *Save and Quit the World* (Step may not be needed)
> 4. Finish off the cleanroom, & place the cleanroom controller **(IMPORTANT: Must Be Placed after STEP 5)**
> 5. Wait until cleanroom is clean, validate that PA runs.
> 6. Quit world, rejoin, PA is no longer running.
> 
> This issue seems to happen if the cleanroom controller is loaded AFTER the PA's first recipe search, causing a lack of sync between the cleanroom state of the PA multiblock and the internal meta tile entity, which handles the logic.
> 
> A seperate issue that also exists due to this syncing issue can be simply reproduced by breaking and re-placing a PA controller in a cleanroom. When the PA forms again, it will not run until you remove and then re-insert the items in the Machine Access Interface.

Fixes #844