### PR TITLE
Add Linear XP Scaling

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -22621,7 +22621,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.",
+          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPlease note that in §5Nomifactory CEu§r, XP scales linearly.\n\nThis means that every XP level §arequires the same amount of XP§r §e(25 XP)§r, and that higher XP levels §ado not require more XP§r.\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29426,7 +29426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and §aXP§r to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Soul Binder§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39804,7 +39804,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r.",
+          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Dark Steel Enchanter§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -27020,7 +27020,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
+          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPlease note that in §5Nomifactory CEu§r, XP scales linearly.\n\nThis means that every XP level §arequires the same amount of XP§r §e(25 XP)§r, and that higher XP levels §ado not require more XP§r.\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34548,7 +34548,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and §aXP§r to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Soul Binder§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46656,7 +46656,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.",
+          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Dark Steel Enchanter§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -841,7 +841,7 @@ general {
 
         # Sets the amount of XP needed for each level, effectively removing the increasing level scaling
         # 0 for vanilla default
-        I:"Linear XP Amount"=0
+        I:"Linear XP Amount"=25
 
         # Sets the amount of applicable pattern layers for banners
         # 6 for vanilla default

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -27020,7 +27020,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
+          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPlease note that in §5Nomifactory CEu§r, XP scales linearly.\n\nThis means that every XP level §arequires the same amount of XP§r §e(25 XP)§r, and that higher XP levels §ado not require more XP§r.\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34548,7 +34548,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and §aXP§r to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Soul Binder§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46656,7 +46656,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.",
+          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Dark Steel Enchanter§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -22621,7 +22621,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.",
+          "desc:8": "§3Anvils§r can be used to repair almost all §bGregTech tools§r!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§r spawn abundantly in §bLost Cities§r buildings, so go and snatch one!\n\nPlease note that in §5Nomifactory CEu§r, XP scales linearly.\n\nThis means that every XP level §arequires the same amount of XP§r §e(25 XP)§r, and that higher XP levels §ado not require more XP§r.\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§r to repair tools made of §6Wrought Iron§r. The only tools unable to be repaired are the mortar and the plunger.\n\nAlso, you can now repair your free §6Mining Hammers§r with some §6Diamonds§r!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29426,7 +29426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and §aXP§r to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Soul Binder§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39804,7 +39804,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r.",
+          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r. Keep in mind that §dMending§r does not work on §3Gregtech Tools§r.\n\nRemember: XP scales linearly! Every level requires the same amount of XP, so don\u0027t be afraid to gather large amounts of §eXP Levels§r, whether it be in your §3Dark Steel Enchanter§r, or simply in your own §6Experience Bar§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -7,6 +7,15 @@
 ##########################################################################################################
 
 advanced {
+    # Amount of XP Per Level, for Linear XP Scaling.
+    # Used for Linear XP Scaling in Actually Additions and EIO Machines.
+    # MUST be used in conjunction with UT's Linear XP Scaling Config, else weird issues may happen!
+    # Enter a value of 0 for default.
+    # [default: 0]
+    # Min: 0
+    # Max: 2147483647
+    I:aaEioLinearXp=25
+
     # Whether to allow other pack modes, other than 'normal' and 'expert'.
     # If this is set to false, the game will crash if other modes are found.
     # Only set this to false if you are sure of what you are doing.
@@ -447,6 +456,11 @@ content {
 ##########################################################################################################
 
 "mod integration" {
+    # Whether to add a Empty Line between any Crafting Recipe Output Tooltips in JEI.
+    # Examples of Crafting Recipe Output Tooltips are `Recipe By <MOD_ID>` and `Recipe ID: <RECIPE_ID>`.
+    # [default: true]
+    B:addJEICraftingOutputEmptyLine=true
+
     # Whether to enable Advanced Rocketry Integration, which fixes Advanced Rocketry registering items for Fluid Blocks.
     # [default: true]
     B:enableAdvancedRocketryIntegration=true

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluids.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluids.groovy
@@ -1,11 +1,15 @@
 import com.nomiceu.nomilabs.fluid.registry.LabsFluids
 import gregtech.api.fluids.FluidState
-import gregtech.api.util.FluidTooltipUtil
 import mezz.jei.api.ingredients.VanillaTypes
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fluids.Fluid
 import net.minecraftforge.fluids.FluidStack
 import net.minecraftforge.fluids.FluidUtil
+
+import java.util.function.Supplier
+
+import static gregtech.api.util.FluidTooltipUtil.*
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 
 /*
  * This File fixes Fluids being Items in JEI, as well as adding GT Tooltips to all Fluids.
@@ -69,7 +73,15 @@ addFluidTooltip(fluid('ender_distillation'))
 addFluidTooltip(fluid('vapor_of_levity'), FluidState.GAS)
 addFluidTooltip(fluid('hootch'))
 addFluidTooltip(fluid('fire_water'))
-addFluidTooltip(fluid('xpjuice'))
+
+// XP (Extra Tooltip)
+Supplier<List<String>> gtTooltip = createFluidTooltip(null, fluid('xpjuice').fluid, FluidState.LIQUID)
+addFluidTooltip(fluid('xpjuice'), () -> {
+	def result = [translate("nomiceu.tooltip.eio.liquid_xp")]
+	result.addAll(gtTooltip.get())
+	return result
+})
+
 addFluidTooltip(fluid('liquid_sunshine'))
 addFluidTooltip(fluid('cloud_seed'))
 addFluidTooltip(fluid('cloud_seed_concentrated'))
@@ -111,17 +123,26 @@ static void fixItemFluid(ItemStack itemForm, FluidStack fluidForm) {
 	mods.jei.ingredient.add(VanillaTypes.FLUID, fluidForm * 1000)
 }
 
+
 /**
  * Adds GT Tooltips to a fluid. Once added, cannot be removed via reloading.
  * (To be replaced by a Labs one in a future version of Labs)
  */
 static void addFluidTooltip(FluidStack fluidForm, FluidState type = FluidState.LIQUID) {
-	var existing = FluidTooltipUtil.getFluidTooltip(fluidForm.fluid)
+	addFluidTooltip(fluidForm, createFluidTooltip(null, fluidForm.fluid, type))
+}
+
+/**
+ * Adds a Tooltips to a fluid. Once added, cannot be removed via reloading.
+ * (To be replaced by a Labs one in a future version of Labs)
+ */
+static void addFluidTooltip(FluidStack fluidForm, Supplier<List<String>> tooltip) {
+	var existing = getFluidTooltip(fluidForm.fluid)
 
 	// Only Register if Not Already Registered (aka previous runs of this script)
 	// However, this is not reloadable. To be fixed in a future version of Labs.
 	if (existing != null && existing.isEmpty())
-		FluidTooltipUtil.registerTooltip(fluidForm.fluid, FluidTooltipUtil.createFluidTooltip(null, fluidForm.fluid, type))
+		registerTooltip(fluidForm.fluid, tooltip)
 }
 
 /**

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -38,16 +38,12 @@ addTooltip(item('actuallyadditions:block_canola_press'), translatable('nomiceu.t
 addTooltip(item('actuallyadditions:item_knife'), translatable('nomiceu.tooltip.actuallyadditions.knife'))
 
 // Solidified XP
-ItemStack solidXp = item('actuallyadditions:item_solidified_experience')
-if (LabsModeHelper.normal) {
-	addTooltip(solidXp, [
-	    translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.1'),
-		translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.2'),
-	])
-} else {
-	addTooltip(solidXp, translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.expert'))
-}
-addTooltip(solidXp, [translatableEmpty(), translatable("nomiceu.tooltip.actuallyadditions.solidifed_xp.amount")])
+addTooltip(item('actuallyadditions:item_solidified_experience'), [
+	translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.desc.1'),
+	translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.desc.2'),
+	translatableEmpty(),
+	translatable("nomiceu.tooltip.actuallyadditions.solidifed_xp.amount"),
+])
 
 /* Advanced Rocketry */
 

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -3,12 +3,19 @@
 
 import appeng.core.AEConfig
 import appeng.core.features.AEFeature
+import com.nomiceu.nomilabs.config.LabsConfig
 import com.nomiceu.nomilabs.util.LabsModeHelper
+import mustapelto.deepmoblearning.common.metadata.MetadataLivingMatter
+import mustapelto.deepmoblearning.common.metadata.MetadataManager
 import net.minecraft.item.ItemStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 import classes.postInit.Common
+
+/* MC */
+// XP Bottle
+addTooltip(item('minecraft:experience_bottle'), translatable("nomiceu.tooltip.mc.xp_bottle"))
 
 /* Actually Additions */
 
@@ -31,14 +38,16 @@ addTooltip(item('actuallyadditions:block_canola_press'), translatable('nomiceu.t
 addTooltip(item('actuallyadditions:item_knife'), translatable('nomiceu.tooltip.actuallyadditions.knife'))
 
 // Solidified XP
+ItemStack solidXp = item('actuallyadditions:item_solidified_experience')
 if (LabsModeHelper.normal) {
-	addTooltip(item('actuallyadditions:item_solidified_experience'), [
+	addTooltip(solidXp, [
 	    translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.1'),
 		translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.2'),
 	])
 } else {
-	addTooltip(item('actuallyadditions:item_solidified_experience'), translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.expert'))
+	addTooltip(solidXp, translatable('nomiceu.tooltip.actuallyadditions.solidifed_xp.expert'))
 }
+addTooltip(solidXp, [translatableEmpty(), translatable("nomiceu.tooltip.actuallyadditions.solidifed_xp.amount")])
 
 /* Advanced Rocketry */
 
@@ -217,10 +226,20 @@ addTooltip(item('dimensionaledibles:island_cake'), [
 // Ender Tether
 addTooltip(item('darkutils:ender_tether'), translatable('nomiceu.tooltip.darkutils.ender_tether'))
 
-/* Deep Mob Learning */
+/* Deep Mob Evolution */
 
 // Glitch Fragment
-addTooltip(item('deepmoblearning:glitch_fragment'), translatable('nomiceu.tooltip.dml.glitch_fragment'))
+addTooltip(item('deepmoblearning:glitch_fragment'), translatable('nomiceu.tooltip.dme.glitch_fragment'))
+
+// Matter
+for (MetadataLivingMatter matter : MetadataManager.livingMatterMetadataList) {
+	// XP is as a Percent of One Level
+	int xpPercent = (matter.xpValue / LabsConfig.advanced.aaEioLinearXp) * 100
+	if (xpPercent == 100)
+		addTooltip(matter.itemStack, translatable('nomiceu.tooltip.dme.matter.full_level'))
+	else
+		addTooltip(matter.itemStack, translatable('nomiceu.tooltip.dme.matter', xpPercent))
+}
 
 /* Thermal Expansion */
 
@@ -251,10 +270,10 @@ addTooltip(metaitem('cover.facade'), [
 /* Ender IO */
 
 // Glasses
-addTooltip(item('enderio:block_fused_glass'), translatable('tooltip.fused_glass.make'))
+addTooltip(item('enderio:block_fused_glass'), translatable('nomiceu.tooltip.eio.fused_glass.make'))
 
 for (ItemStack stack in Common.eioGlasses) {
-	addTooltip(stack, translatable('tooltip.eio_glass.dye'))
+	addTooltip(stack, translatable('nomiceu.tooltip.eio.glass.dye'))
 }
 
 /* Project Red */

--- a/overrides/groovy/postInit/Post-Initial/Main/Mode-Specific/Normal-Mode/dmeSimChamber.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mode-Specific/Normal-Mode/dmeSimChamber.groovy
@@ -1,4 +1,3 @@
-import com.nomiceu.nomilabs.LabsValues
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import mustapelto.deepmoblearning.common.metadata.MetadataDataModel
 import mustapelto.deepmoblearning.common.metadata.MetadataManager

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -3,6 +3,9 @@ nomifactory.nonetherportals=Nether portals are disabled in §5Nomi-CEu§r. Follo
 
 # Tooltips
 
+# MC
+nomiceu.tooltip.mc.xp_bottle=§eGives 25 XP, or one XP Level!§r
+
 # Actually Additions
 nomiceu.tooltip.actuallyadditions.drill_core.1=§cAcquired by exploration of Lost Cities buildings or vanilla dungeons.§r
 nomiceu.tooltip.actuallyadditions.drill_core.2=§cAlso can be purchased for Nomicoins!§r
@@ -13,6 +16,9 @@ nomiceu.tooltip.actuallyadditions.knife=§cWhen making Hamburgers, make sure to 
 nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.1=§aDrops from monsters, and can be made in§r
 nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.2=§aa Fluid Solidifier or Experience Solidifier.§r
 nomiceu.tooltip.actuallyadditions.solidifed_xp.expert=§aMade in a Fluid Solidifier or Experience Solidifier.§r
+
+# Output: §eGives 8 XP, of 32% of a XP Level!§r (% is Escaped)
+nomiceu.tooltip.actuallyadditions.solidifed_xp.amount=§eGives 8 XP, of 32%% of a XP Level!§r
 
 # Advanced Rocketry
 nomiceu.tooltip.advancedrocketry.orbital_laser_drill.1=§7Glory to the PGS!§r
@@ -59,8 +65,12 @@ nomiceu.tooltip.dimensionaledibles.island_cake.2=§aView the Server Information 
 # Dark Utils
 nomiceu.tooltip.darkutils.ender_tether=Blocks Endermen from teleporting.
 
-# Deep Mob Learning
-nomiceu.tooltip.dml.glitch_fragment=§bObtained by crushing Glitch Hearts against Obsidian.§r
+# Deep Mob Evolution
+nomiceu.tooltip.dme.glitch_fragment=§bObtained by crushing Glitch Hearts against Obsidian.§r
+
+# Output: §eGives (AMOUNT)% of a XP Level!§r (% is Escaped)
+nomiceu.tooltip.dme.matter=§eGives %s%% of a XP Level!§r
+nomiceu.tooltip.dme.matter.full_level=§eGives One XP Level!§r
 
 # Thermal Expansion
 nomiceu.tooltip.thermalexpansion.capacitors=§cCannot be discharged in GT Battery Buffers!§r
@@ -74,8 +84,9 @@ nomiceu.tooltip.gregtech.facade.1=§3GTCEu facades can be made from most non-til
 nomiceu.tooltip.gregtech.facade.2=§3They craft into different amounts based on the metal used!§r
 
 # Ender IO
-tooltip.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r
-tooltip.eio_glass.dye=Can be §bDyed§r!
+nomiceu.tooltip.eio.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r
+nomiceu.tooltip.eio.glass.dye=Can be §bDyed§r!
+nomiceu.tooltip.eio.liquid_xp=§e20L = 1XP, 500L = 1 XP Level!§r
 
 # Project Red
 nomiceu.tooltip.projectred.wire=§eFor use with ProjectRed.§r

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -13,9 +13,8 @@ nomiceu.tooltip.actuallyadditions.canola.1=§aCanola can be turned into Canola O
 nomiceu.tooltip.actuallyadditions.canola.2=§aThis is a somewhat slow machine and requres RF to function.§r
 nomiceu.tooltip.actuallyadditions.canola_press=§aTurns Canola into Canola Oil. Requires RF.§r
 nomiceu.tooltip.actuallyadditions.knife=§cWhen making Hamburgers, make sure to place this in the Crafting Table last!§r
-nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.1=§aDrops from monsters, and can be made in§r
-nomiceu.tooltip.actuallyadditions.solidifed_xp.normal.2=§aa Fluid Solidifier or Experience Solidifier.§r
-nomiceu.tooltip.actuallyadditions.solidifed_xp.expert=§aMade in a Fluid Solidifier or Experience Solidifier.§r
+nomiceu.tooltip.actuallyadditions.solidifed_xp.desc.1=§aDrops from monsters, and can be made in§r
+nomiceu.tooltip.actuallyadditions.solidifed_xp.desc.2=§aa Fluid Solidifier or Experience Solidifier.§r
 
 # Output: §eGives 8 XP, of 32% of a XP Level!§r (% is Escaped)
 nomiceu.tooltip.actuallyadditions.solidifed_xp.amount=§eGives 8 XP, of 32%% of a XP Level!§r

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -157,6 +157,10 @@
       "expert": 399
     },
     {
+      "normal": 401,
+      "expert": 401
+    },
+    {
       "normal": 402,
       "expert": 402
     },
@@ -207,6 +211,10 @@
     {
       "normal": 729,
       "expert": 729
+    },
+    {
+      "normal": 747,
+      "expert": 747
     },
     {
       "normal": 750,


### PR DESCRIPTION
This PR makes XP scale linearly, for players gaining XP, for Actually Additions & EIO Machines, and adds tooltips to relevant XP items, stating how much XP levels, they give.

This essentially means that exactly 25 XP is required for **each** xp level, which is equal to one `Extraterrestrial Matter`.

This PR also adds a note to the `Proper Tool Care`, `Dark Steel Enchanter` and `Soul Binder` quests, stating (or reminding players) that XP scales linearly.

Other small change: Makes Solidified XP tooltips the same across both modes. Previously, the tooltip regarding obtaining Solidified XP via killing of mobs was removed due a misunderstanding that it meant hostile mobs only.