### PR TITLE
Add Fillable Tooltip to Various Items

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -13,6 +13,26 @@ import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 import classes.postInit.Common
 
+/* Mixed */
+// Fillable Items
+List<ItemStack> fillable = [
+	metaitem('fluid_cell'),
+	metaitem('fluid_cell.universal'),
+	metaitem('large_fluid_cell.steel'),
+	metaitem('large_fluid_cell.aluminium'),
+	metaitem('large_fluid_cell.stainless_steel'),
+	metaitem('large_fluid_cell.titanium'),
+	metaitem('large_fluid_cell.tungstensteel'),
+	metaitem('fluid_cell.glass_vial'),
+	item('minecraft:bucket'),
+	item('minecraft:water_bucket'),
+	item('minecraft:lava_bucket'),
+	item('forge:bucketfilled'),
+]
+for (ItemStack fill : fillable) {
+	addTooltip(fill, translatable('nomiceu.tooltip.mixed.fillable'))
+}
+
 /* MC */
 // XP Bottle
 addTooltip(item('minecraft:experience_bottle'), translatable("nomiceu.tooltip.mc.xp_bottle"))

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -3,6 +3,9 @@ nomifactory.nonetherportals=Nether portals are disabled in §5Nomi-CEu§r. Follo
 
 # Tooltips
 
+# Mixed
+nomiceu.tooltip.mixed.fillable=Can be filled with the §bCanning Machine§r.
+
 # MC
 nomiceu.tooltip.mc.xp_bottle=§eGives 25 XP, or one XP Level!§r
 


### PR DESCRIPTION
This PR adds a tooltip stating that the item can be filled with the Canning Machine, to various items.