### PR TITLE
Hide Modded Buckets from JEI

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -20,6 +20,9 @@ if (LabsModeHelper.expert) {
 	mods.jei.ingredient.removeAndHide(item('nomilabs:impossiblerealmdata'))
 }
 
+// Modded Buckets
+hideItemIgnoreNBT(item('forge:bucketfilled'))
+
 /* Remove Categories (Appear Randomly after /gs reload) */
 // Avatitia
 mods.jei.category.hideCategory('Avatitia.Extreme')


### PR DESCRIPTION
This PR cleans up JEI by hiding modded buckets from JEI.

Note: the Normal Bucket Item, the Water Bucket and the Lava Bucket are not hidden from JEI.

These bucket items have no recipes, and they are useless thanks to ghost dragging 'fluid' items from JEI. 