### PR TITLE
Nether Star Block -> Nether Star Crafting Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Mid-Game/midgame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Mid-Game/midgame.groovy
@@ -19,3 +19,6 @@ mods.gregtech.centrifuge.recipeBuilder()
     .chancedOutput(metaitem('dustLanthanum'), 625, 100)
     .duration(64).EUt(VA[LV])
     .buildAndRegister()
+
+// Nether Star Block -> Nether Star
+crafting.addShapeless(item('minecraft:nether_star') * 9, [ore('blockNetherStar')])


### PR DESCRIPTION
This PR simply adds a Nether Star block to Nether Star crafting recipe.