### PR TITLE
Fix Server GrS Errors

### DIFF
--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -43,6 +43,19 @@ advanced {
     # Many Client Side Only modifications, on the same class, may be inefficient.
     # [default: ]
     S:clientSideMethods <
+        eutros/framedcompactdrawers/item/ItemSlaveCustom@func_77624_a@(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Ljava/util/List;Lnet/minecraft/client/util/ITooltipFlag;)V
+        gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
+        gregtech/api/recipes/recipeproperties/CleanroomProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/ComputationProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/DefaultProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/FusionEUToStartProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/GasCollectorDimensionProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/ImplosionExplosiveProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/PrimitiveProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/ResearchProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/ScanProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/TotalComputationProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
      >
 
     # Whether to disable the Narrator.

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/diodes.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/diodes.groovy
@@ -1,13 +1,11 @@
 import com.cleanroommc.groovyscript.api.IIngredient
 import gregtech.api.items.metaitem.MetaItem
-import gregtech.api.metatileentity.MetaTileEntity
 import gregtech.api.unification.OreDictUnifier
 import gregtech.api.unification.ore.OrePrefix
 import gregtech.api.unification.stack.UnificationEntry
 import gregtech.common.metatileentities.MetaTileEntities
 import net.minecraft.item.ItemStack
 
-import static com.nomiceu.nomilabs.groovy.GroovyHelpers.SafeMethodHelpers.callInstanceMethodOfClass
 import static gregtech.loaders.recipe.CraftingComponent.*;
 import static gregtech.api.GTValues.*
 
@@ -27,11 +25,7 @@ void replaceRecipe(int minTier, int maxTier, IIngredient oreDict) {
 		def hull = getIngredientFromGTComponent(HULL, tier)
 		def plate = getIngredientFromGTComponent(PLATE, tier)
 		def cable = getIngredientFromGTComponent(CABLE_QUAD, tier)
-
-		// We must use Safe Method Helpers
-		// MetaTileEntityMultiblockPart has a method with TextureAtlasSprite not labelled as @SideOnly(Side.CLIENT)
-		// Direct call to MetaTileEntity
-		def diode = callInstanceMethodOfClass(MetaTileEntity.class, MetaTileEntities.DIODES[tier], "getStackForm", null)
+		def diode = MetaTileEntities.DIODES[tier].getStackForm()
 
 		crafting.shapedBuilder()
 			.output(diode)

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
@@ -2,14 +2,10 @@ import com.cleanroommc.groovyscript.api.IIngredient
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IFrameable
 import com.nomiceu.nomilabs.groovy.ShapedDummyRecipe
 import com.nomiceu.nomilabs.util.ItemMeta
-import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
-import net.minecraft.util.ResourceLocation
-import net.minecraftforge.registries.IForgeRegistryEntry
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.addRecipeOutputTooltip
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
-import static com.nomiceu.nomilabs.groovy.GroovyHelpers.SafeMethodHelpers.callInstanceMethodOfClass
 
 // Hand Framing Tool
 crafting.addShaped("hand_framing_tool_recipe", item("nomilabs:hand_framing_tool"), [
@@ -73,7 +69,7 @@ static String getRecipeName(ItemStack stack, boolean trim, boolean front) {
 	// We have to use safe method helpers, because some items from Framed Compacting Drawers mislabel addInformation,
 	// Without SideOnly, so it crashes.
 	// Use the special of class type so the addInformation method isn't loaded.
-	def rl = (ResourceLocation) callInstanceMethodOfClass(IForgeRegistryEntry<Item>.class, stack.getItem(), "getRegistryName", null)
+	def rl = stack.getItem().getRegistryName()
 	if (rl != null)
 		baseName = baseName + rl.getNamespace() + "_" + rl.getPath()
 
@@ -88,11 +84,8 @@ static ItemStack addNBT(ItemStack stack, boolean trim, boolean front) {
 	def trimStack = trim ? item("extendedcrafting:storage", 4) : ItemStack.EMPTY
 	def frontStack = front ? item("xtones:zane", 15) : ItemStack.EMPTY
 
-	// We have to use safe method helpers, because some items from Framed Compacting Drawers mislabel addInformation,
-	// Without SideOnly, so it crashes.
-	// Use the special of class type so the addInformation method isn't loaded.
 	def frameable = (IFrameable) stack.getItem()
-	stack = (ItemStack) callInstanceMethodOfClass(IFrameable.class, frameable, "decorate", [stack.copy(), sideStack, trimStack, frontStack])
+	stack = frameable.decorate(stack.copy(), sideStack, trimStack, frontStack)
 	if (stack == null)
 		return stack
 


### PR DESCRIPTION
This PR fixes server GrS errors by marking many functions, of recipe properties, as client side only.

This PR also removes usage of SafeMethodHelpers in favour of client side only methods.