### PR TITLE
Update Nomi-Labs to v0.8.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5601481,
+      "fileID": 5601600,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -28,7 +28,7 @@ advanced {
     # Helps with fixing GrS errors Server Side.
     # Format: <CLASS>@<FIELD>
     # Example: gregtech/api/recipes/recipeproperties/TemperatureProperty@KEY
-    # Accepts Obfuscated Fields.
+    # Accepts Obfuscated Fields, but they must be under the Obfuscated Name.
     # Many Client Side Only modifications, on the same class, may be inefficient.
     # [default: ]
     S:clientSideFields <
@@ -39,7 +39,7 @@ advanced {
     # Helps with fixing GrS errors Server Side.
     # Format: <CLASS>@<METHOD>@<DESC>
     # Example: gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
-    # Accepts Obfuscated Methods.
+    # Accepts Obfuscated Methods, but they must be under the Obfuscated Name.
     # Many Client Side Only modifications, on the same class, may be inefficient.
     # [default: ]
     S:clientSideMethods <
@@ -138,7 +138,7 @@ advanced {
     # Helps with fixing GrS errors Client Side.
     # Format: <CLASS>@<FIELD>
     # Example: gregtech/api/recipes/recipeproperties/TemperatureProperty@KEY
-    # Accepts Obfuscated Fields.
+    # Accepts Obfuscated Fields, but they must be under the Obfuscated Name.
     # Many Server Side Only modifications, on the same class, may be inefficient.
     # [default: ]
     S:serverSideFields <
@@ -149,7 +149,7 @@ advanced {
     # Helps with fixing GrS errors Client Side.
     # Format: <CLASS>@<METHOD>@<DESC>
     # Example: gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
-    # Accepts Obfuscated Methods.
+    # Accepts Obfuscated Methods, but they must be under the Obfuscated Name.
     # Many Server Side Only modifications, on the same class, may be inefficient.
     # [default: ]
     S:serverSideMethods <


### PR DESCRIPTION
This PR simply updates Labs to 0.8.6, and updates its config. This release fixes an issue with saving fix data.