### PR TITLE
Abolish Draconic Injector Energy Limits

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -696,7 +696,7 @@
     },
     {
       "projectID": 833931,
-      "fileID": 5299168,
+      "fileID": 5598456,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -610,10 +610,10 @@ content {
         # Min: 1
         # Max: 2147483647
         I:fusionChargingTime <
-            300
-            220
-            140
-            60
+            1
+            1
+            1
+            1
          >
     }
 

--- a/overrides/config/packageddraconic.cfg
+++ b/overrides/config/packageddraconic.cfg
@@ -1,0 +1,36 @@
+# Configuration file
+
+blocks {
+
+    fusion_crafter {
+        # Should the Fusion Packager Crafter draw energy from ME systems.
+        B:draw_me_energy=true
+
+        # How much FE the Fusion Package Crafter should hold.
+        I:energy_capacity=5000
+
+        # How much FE/t the Fusion Package Crafter should use.
+        I:energy_usage=5
+    }
+
+    marked_injector {
+        # Rough time in ticks required for the charging phase of package fusion crafting with each injector tier.
+        I:charge_rate <
+            1
+            1
+            1
+            1
+         >
+
+        # How much (out of 1000) the crafting phase of package fusion crafting should progress with each injector tier. The minimum progress will be used.
+        I:craft_rate <
+            2
+            3
+            5
+            7
+         >
+    }
+
+}
+
+


### PR DESCRIPTION
This PR simply abolishes energy limits for Draconic Evolution and Packaged Draconic's injectors, effectively allowing for instant crafting assuming throughput is enough.