### PR TITLE
Revamp Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <h1 align="center">Nomifactory CEu</h1>
 <p align="center"><b><i>Fork of <a href="https://github.com/Nomifactory/Nomifactory"> Nomifactory</a>, using <a href="https://github.com/GregTechCEu/GregTech"> GregTech CEu</a> and its related mods.</i></b></p>
 <h1 align="center">
-    <a href="https://github.com/Nomi-CEu/Nomi-CEu/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Nomi-CEu/Nomi-CEu?style=for-the-badge&logo=github" alt="License"></a>
-    <a href="https://nightly.link/Nomi-CEu/Nomi-CEu/workflows/testbuildpack/main"><img src="https://img.shields.io/github/actions/workflow/status/Nomi-CEu/Nomi-CEu/testbuildpack.yml?style=for-the-badge&logo=github&label=builds&color=orange" alt="Builds"></a>
+    <a href="https://github.com/Nomi-CEu/Nomi-CEu/blob/main/LICENSE"><img src="https://img.shields.io/github/stars/Nomi-CEu/Nomi-CEu?style=for-the-badge&logo=github&logoColor=white" alt="License"></a>
+    <a href="https://nightly.link/Nomi-CEu/Nomi-CEu/workflows/testbuildpack/main"><img src="https://img.shields.io/github/last-commit/Nomi-CEu/Nomi-CEu/main?style=for-the-badge&logo=githubactions&logoColor=white&label=Nightly%20Builds&color=%238a67ab" alt="Builds"></a>
     <a href="https://discord.com/invite/zwQzqP8b6q"><img src="https://img.shields.io/discord/927050775073534012?style=for-the-badge&logo=discord&logoColor=%23ffffff&label=discord%20&labelColor=gray&color=%235865F2" alt="Discord"></a>
     <br>
     <a href="https://www.curseforge.com/minecraft/modpacks/Nomi-CEu"><img src="https://cf.way2muchnoise.eu/nomi-ceu.svg?badge_style=for_the_badge" alt="CurseForge"></a>


### PR DESCRIPTION
This PR makes two changes:
- Changes the Nightly Builds Badge:
  - Logo to Github Actions Logo
  - Color Change
  - Displays 'Last Commit' instead of status of the Action
- Replaces the License Badge with a Star Badge