### PR TITLE
Make Salt Water Deposit Infinite

### DIFF
--- a/overrides/config/gregtech/worldgen/fluid/overworld/salt_water_deposit.json
+++ b/overrides/config/gregtech/worldgen/fluid/overworld/salt_water_deposit.json
@@ -1,14 +1,14 @@
 {
   "weight": 0,
-  "name": "Overworld Salt Water Deposit",
+  "name": "Overworld Infinite Salt Water Deposit",
   "yield": {
     "min": 50,
     "max": 100
   },
   "depletion": {
-    "amount": 1,
-    "chance": 100,
-    "depleted_yield": 15
+    "amount": 0,
+    "chance": 0,
+    "depleted_yield": 50
   },
   "fluid": "salt_water",
   "dimension_filter": [


### PR DESCRIPTION
This PR makes the Overworld/Lost Cities Salt Water Deposit infinite. This is mainly due to this deposit's large usage in HM, causing players to move around their drills in the late game, due to the large disparity between the normal and depleted yields.