### PR TITLE
Fix Recycling Recipes of Tantalum Capacitors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5604686,
+      "fileID": 5611187,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi-Labs, fixing a processing error with recycling recipes, which fixes tantalum and manganese duplication with Tantalum Capacitors.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/876