### PR TITLE
Improve Port QB Task

### DIFF
--- a/tools/globals.ts
+++ b/tools/globals.ts
@@ -42,8 +42,8 @@ export const rootDirectory = "..";
 export const templatesFolder = "templates";
 export const storageFolder = "storage";
 
-// The Repository Owner (For Issues & PR Tags Transforms in Changelog)
+// The GitHub Repository Owner
 export const repoOwner = "Nomi-CEu";
 
-// The Repository Name (For Issues & PR Tags Transforms in Changelog)
+// The GitHub Repository Name
 export const repoName = "Nomi-CEu";

--- a/tools/gulpfile.ts
+++ b/tools/gulpfile.ts
@@ -69,4 +69,4 @@ export const checkQB = checkFix.check;
 export const fixQB = checkFix.fix;
 
 import * as qbPort from "./tasks/helpers/questPorting/index.ts";
-export const portQBChanges = gulp.series(qbPort.default, fixQB);
+export const portQB = gulp.series(qbPort.default, fixQB);

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -1,6 +1,10 @@
 {
   "savedQuestMap": [
     {
+      "normal": 0,
+      "expert": 0
+    },
+    {
       "normal": 3,
       "expert": 3
     },
@@ -15,6 +19,10 @@
     {
       "normal": 22,
       "expert": 22
+    },
+    {
+      "normal": 26,
+      "expert": 26
     },
     {
       "normal": 38,

--- a/tools/tasks/helpers/questPorting/index.ts
+++ b/tools/tasks/helpers/questPorting/index.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import upath from "upath";
 import { rootDirectory } from "#globals";
 import { Quest, QuestBook, QuestLine } from "#types/bqQuestBook.ts";
-import { getFileAtRevision } from "#utils/util.ts";
+import { getFileAtRevision, git } from "#utils/util.ts";
 import { getChanged, id, save, setupUtils } from "../actionQBUtils.ts";
 import PortQBData from "./portQBData.ts";
 import {
@@ -12,7 +12,7 @@ import {
 	setupLogic,
 } from "./portQBLogic.ts";
 import { setupModifications } from "./portQBModifications.ts";
-import logInfo, { logError } from "../../../utils/log.ts";
+import logInfo, { logError, logNotImportant } from "#utils/log.ts";
 
 let data: PortQBData;
 
@@ -32,6 +32,12 @@ export default async function portQBChanges(): Promise<void> {
 	const old = JSON.parse(
 		await getFileAtRevision(data.srcPath, data.ref),
 	) as QuestBook;
+
+	// Now we have used the ref, delete branch
+	if (data.createdBranch) {
+		await git.deleteLocalBranch(data.ref);
+		logNotImportant(`Deleted Temp Branch ${data.ref}`);
+	}
 
 	const currentQuests = Object.values(current["questDatabase:9"]);
 	const oldQuests = Object.values(old["questDatabase:9"]);

--- a/tools/tasks/helpers/questPorting/portQBModifications.ts
+++ b/tools/tasks/helpers/questPorting/portQBModifications.ts
@@ -20,7 +20,7 @@ import fakeDiff from "fake-diff";
 import { Operation } from "just-diff";
 import logInfo, { logError, logNotImportant, logWarn } from "#utils/log.ts";
 import dedent from "dedent-js";
-import { confirm, editor, input, select } from "@inquirer/prompts";
+import { editor, input, select } from "@inquirer/prompts";
 import colors from "colors";
 import { stringify } from "javascript-stringify";
 import { Quest, Task } from "#types/bqQuestBook.ts";
@@ -784,9 +784,9 @@ const modifyGeneral = async (
 		),
 	);
 
-	const shouldContinue = await confirm({
-		message: "Would you like to apply the Change?",
-	});
+	const shouldContinue = await booleanSelect(
+		"Would you like to apply this Change?",
+	);
 	if (!shouldContinue) {
 		logNotImportant("Skipping...");
 		return;

--- a/tools/utils/util.ts
+++ b/tools/utils/util.ts
@@ -43,7 +43,7 @@ import { BuildData } from "#types/transformFiles.js";
 const LIBRARY_REG = /^(.+?):(.+?):(.+?)$/;
 
 // Make git commands run in root dir
-const git: SimpleGit = simpleGit(rootDirectory);
+export const git: SimpleGit = simpleGit(rootDirectory);
 
 const retryCfg: IAxiosRetryConfig = {
 	retries: 10,
@@ -747,6 +747,13 @@ export async function formatAuthor(commit: Commit, octokit: Octokit) {
 		commitAuthorCache.set(commit.hash, "");
 		return defaultFormat;
 	}
+}
+
+/**
+ * List all Remotes in the Git Repository.
+ */
+export async function listRemotes(): Promise<string[]> {
+	return git.getRemotes().then((r) => r.map((re) => re.name));
 }
 
 export const FORGE_VERSION_REG = /forge-(.+)/;


### PR DESCRIPTION
This PR improves the Port QB Task, adding a functionality to automatically add the Nomi-CEu/Nomi-CEu remote, and create a new branch from that remote, allowing for easier usage of this task on Forks.

Note: The Gulp Task has changed from 'portQBChanges' to 'portQB'.