### PR TITLE
Fix Dupe Glitch with BogoSorter and Thermal Satchels

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5611187,
+      "fileID": 5617292,
       "required": true
     },
     {


### PR DESCRIPTION
This PR simply updates Nomi Labs to v0.8.9, which prevents Inventory BogoSorter from sorting slots which do not allow players to take stacks.

This prevents a duplication glitch with thermal satchels.