### PR TITLE
Fix Porting QB Changes from Expert to Normal

### DIFF
--- a/tools/tasks/helpers/questPorting/portQBData.ts
+++ b/tools/tasks/helpers/questPorting/portQBData.ts
@@ -178,7 +178,7 @@ export default class PortQBData {
 					this.sourceOption === "CFG" ? cfgExpertPath : cfgOverrideExpertPath;
 				this.srcPathToChange =
 					this.sourceOption === "CFG" ? cfgNormalPath : cfgOverrideNormalPath;
-				this.outputPaths = [cfgExpertPath, cfgOverrideExpertPath];
+				this.outputPaths = [cfgNormalPath, cfgOverrideNormalPath];
 				break;
 		}
 


### PR DESCRIPTION
This PR simply fixes running the QB Port script from Expert -> Normal.

Yes, this is the first time that changes have been ported from Expert to Normal, since the initial creation of the script.