### PR TITLE
Fix Inventory BogoSorter Default Sort Keybind

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -50347,7 +50347,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory!\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in the inventory (§6Chests§r, §6Crates§r, your personal inventory, etc.), and click your sort keybind, and voila! A neat inventory.\n\nYou can also configure how it is sorted, within the GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also replaces stacks of items, like blocks, tools and food in your hotbar. For tools, it even replaces it just before it breaks, so you can repair it! Now, you can build a pillar to y-256 without opening your inventory, or changing hotbar slots!",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -63533,7 +63533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory!\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in the inventory (§6Chests§r, §6Crates§r, your personal inventory, etc.), and click your sort keybind, and voila! A neat inventory.\n\nYou can also configure how it is sorted, within the GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also replaces stacks of items, like blocks, tools and food in your hotbar. For tools, it even replaces it just before it breaks, so you can repair it! Now, you can build a pillar to y-256 without opening your inventory, or changing hotbar slots!",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -63533,7 +63533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory!\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in the inventory (§6Chests§r, §6Crates§r, your personal inventory, etc.), and click your sort keybind, and voila! A neat inventory.\n\nYou can also configure how it is sorted, within the GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also replaces stacks of items, like blocks, tools and food in your hotbar. For tools, it even replaces it just before it breaks, so you can repair it! Now, you can build a pillar to y-256 without opening your inventory, or changing hotbar slots!",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -50347,7 +50347,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory!\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in the inventory (§6Chests§r, §6Crates§r, your personal inventory, etc.), and click your sort keybind, and voila! A neat inventory.\n\nYou can also configure how it is sorted, within the GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also replaces stacks of items, like blocks, tools and food in your hotbar. For tools, it even replaces it just before it breaks, so you can repair it! Now, you can build a pillar to y-256 without opening your inventory, or changing hotbar slots!",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
@@ -38,6 +38,8 @@ addOverride('key.ftbutilities.trash', Keyboard.KEY_NONE)
 
 addOverride('key.groovyscript.reload', Keyboard.KEY_NONE)
 
+addOverride("key.sort", Keyboard.KEY_RETURN)
+
 addOverride('key.journeymap.fullscreen_chat_position', Keyboard.KEY_NONE)
 
 addOverride('key.little.config', Keyboard.KEY_L)

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -321,6 +321,10 @@
       "expert": 930
     },
     {
+      "normal": 1024,
+      "expert": 932
+    },
+    {
       "normal": 1027,
       "expert": 935
     },


### PR DESCRIPTION
This PR changes the Inventory BogoSorter's default sort keybind to RETURN. The original default, Middle Click, does not work.

This PR also updates the relevant quest with the change, and increases the clarity of that quest.