### PR TITLE
Change Default Sort Keybind back to Middle Click

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -50347,7 +50347,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -63533,7 +63533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -63533,7 +63533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -50347,7 +50347,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aEnter / Return§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
+          "desc:8": "This pack has §bInventory Bogo Sorter§r, allowing for quick, customizable, and easy sorting of any inventory.\n\nThe default sort keybind is §aMiddle Click§r, but you can always change the keybind. Simply hover over any slot in an inventory (§eChests§r, §eCrates§r, §ePlayer Inventory§r, etc.), click the sort keybind, and voila! A neat inventory.\n\nYou can also configure how your items are sorted within the Config GUI. The default key to open the GUI is §aK§r.\n\nInventory Bogo Sorter, by default, also §erefills stacks of items§r, like blocks, tools and food, from your inventory to your hotbar. For tools, it replaces it §ejust before it breaks§r, so you can repair it.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
@@ -38,7 +38,9 @@ addOverride('key.ftbutilities.trash', Keyboard.KEY_NONE)
 
 addOverride('key.groovyscript.reload', Keyboard.KEY_NONE)
 
-addOverride("key.sort", Keyboard.KEY_RETURN)
+// Doesn't affect ability to move bookmarks for some reason?
+// Also fixes Middle Click not working for sorting inventory
+addOverride("key.jeiutilities.pickBookmark", Keyboard.KEY_NONE)
 
 addOverride('key.journeymap.fullscreen_chat_position', Keyboard.KEY_NONE)
 


### PR DESCRIPTION
This PR changes the default sort keybind back to middle click.

However, this PR changes a redundant keybind, which results in the middle click keybind working as expected.