### PR TITLE
Fix Auto Remote Fetching from Nomi-CEu/Nomi-CEu

### DIFF
--- a/tools/tasks/helpers/questPorting/portQBData.ts
+++ b/tools/tasks/helpers/questPorting/portQBData.ts
@@ -116,10 +116,13 @@ export default class PortQBData {
 				throw new Error("Branch already Exists!");
 			}
 
+			// Fetch
+			await git.fetch(remote);
+
 			// Create the Ref Branch, tracking the remote's main branch, but do not switch to it
 			const currBranch = (await git.raw(["branch", "--show-current"])).trim();
 			await git.stash();
-			await git.checkoutBranch(this.ref, `${remote}/main`);
+			await git.checkoutBranch(this.ref, `remotes/${remote}/main`);
 			await git.checkout(currBranch);
 
 			// Pop the newest stash (the one we just created)


### PR DESCRIPTION
This PR fetches the new remote created in the QB port task, before creating a branch from it, hopefully fixing issues with git not detecting branches in the created remote.