### PR TITLE
Update Nomi Labs to v0.8.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -746,7 +746,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5617292,
+      "fileID": 5620594,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs to v0.8.10, fixing an issue transporting items with a stack size of 1 into inventories with 1 slots (Drawers, GT Super/Quantum Chests, etc.), and fixing localisation of GT Fluids in TOP.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/420