### PR TITLE
New FTB Utilities Default Settings

### DIFF
--- a/overrides/local/ftbutilities/ranks.txt
+++ b/overrides/local/ftbutilities/ranks.txt
@@ -3,20 +3,16 @@
 [player]
 default_player_rank: true
 power: 1
-example.permission: true
-example.other_permission: false
-example.permission_with_value: 0
-ftbutilities.homes.max: 10
+ftbutilities.homes.max: 25
 ftbutilities.homes.cooldown: 0
+ftbutilities.claims.max_chunks: 2000
+ftbutilities.chunkloader.max_chunks: 1000
 
 [vip]
 power: 20
 ftbutilities.chat.name_format: <&bVIP {name}&r>
-example.other_permission: true
-example.permission_with_value: 15
 
 [admin]
 default_op_rank: true
 power: 100
-ftbutilities.chat.name_format: <&2{name}&r>
-example.permission_with_value: 100
+ftbutilities.chat.name_format: <&3{name}&r>


### PR DESCRIPTION
This PR changes the FTB Utilities default settings, to remove useless example properties, changing default max claimed chunks, max chunkloaded chunks and max homes, as well as slightly changing the default color of Admin Messages.