### PR TITLE
Remove EIO Explosions

### DIFF
--- a/overrides/config/enderio/enderio.cfg
+++ b/overrides/config/enderio/enderio.cfg
@@ -139,7 +139,7 @@ diagnostics {
     B:experimentalChunkLoadTeleport=true
 
     # Should TEs protected their maximum energy input against multiple inserts? [default: SOFT]
-    S:protectAgainstEnergyOverflow=HARD
+    S:protectAgainstEnergyOverflow=SOFT
 }
 
 


### PR DESCRIPTION
This PR removes EIO explosions caused by energy overflow into EIO machines, which can happen from Energy P2Ps as well as using World Accelerators.