### PR TITLE
Apply Prettier to Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -89,17 +89,13 @@
       "projectID": 226406,
       "fileID": 2857869,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 226447,
       "fileID": 2477566,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 227083,
@@ -185,9 +181,7 @@
       "projectID": 238747,
       "fileID": 2739582,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 239197,
@@ -228,9 +222,7 @@
       "projectID": 243478,
       "fileID": 2745657,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 244559,
@@ -286,9 +278,7 @@
       "projectID": 250398,
       "fileID": 4428378,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 250419,
@@ -304,9 +294,7 @@
       "projectID": 251407,
       "fileID": 2624712,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 251792,
@@ -397,9 +385,7 @@
       "projectID": 267602,
       "fileID": 2915363,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 269024,
@@ -455,9 +441,7 @@
       "projectID": 282313,
       "fileID": 2689835,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 283644,
@@ -473,9 +457,7 @@
       "projectID": 297038,
       "fileID": 5165348,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 297209,
@@ -521,9 +503,7 @@
       "projectID": 306555,
       "fileID": 2707092,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 306770,
@@ -579,9 +559,7 @@
       "projectID": 383632,
       "fileID": 3056455,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 391401,
@@ -612,9 +590,7 @@
       "projectID": 461660,
       "fileID": 4661407,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 490698,
@@ -625,9 +601,7 @@
       "projectID": 513857,
       "fileID": 3739783,
       "required": true,
-      "sides": [
-        "client"
-      ]
+      "sides": ["client"]
     },
     {
       "projectID": 557242,


### PR DESCRIPTION
This PR simply applies prettier to the manifest, condensing side only mod specifications into one line.