### PR TITLE
Update Labs to v0.8.11

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -720,7 +720,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5620594,
+      "fileID": 5624443,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -7,15 +7,6 @@
 ##########################################################################################################
 
 advanced {
-    # Amount of XP Per Level, for Linear XP Scaling.
-    # Used for Linear XP Scaling in Actually Additions and EIO Machines.
-    # MUST be used in conjunction with UT's Linear XP Scaling Config, else weird issues may happen!
-    # Enter a value of 0 for default.
-    # [default: 0]
-    # Min: 0
-    # Max: 2147483647
-    I:aaEioLinearXp=25
-
     # Whether to allow other pack modes, other than 'normal' and 'expert'.
     # If this is set to false, the game will crash if other modes are found.
     # Only set this to false if you are sure of what you are doing.
@@ -127,6 +118,16 @@ advanced {
     # NOMI
     S:languageModifyOption=NOMI
 
+    # Amount of XP Per Level, for Linear XP Scaling.
+    # Used for Linear XP Scaling in Actually Additions, EIO and Thermal Items/Machines.
+    # Note that for Thermal, XP fixes are only applied for the Tome of Knowledge, not for any machines associated with Essence of Knowledge.
+    # MUST be used in conjunction with UT's Linear XP Scaling Config, else weird issues may happen!
+    # Enter a value of 0 for default.
+    # [default: 0]
+    # Min: 0
+    # Max: 2147483647
+    I:otherModsLinearXp=25
+
     # Whether to enable Substitutions for the Server Properties MOTD.
     # Substitutions: {version} for the Modpack Formatted Version (from 'nomilabs-version.cfg'), {mode} for the Modpack Formatted Mode (from LabsModeHelper & the PackMode Mod).
     # Note: Only the First Substitution in the String is Replaced!
@@ -154,11 +155,6 @@ advanced {
     # [default: ]
     S:serverSideMethods <
      >
-
-    # Whether to enable Syncing between Dimensions.
-    # This means that changing difficulty, time, spawn point or other properties in one dimension will sync to all dimensions.
-    # [default: false]
-    B:syncDimProperties=true
 
     ##########################################################################################################
     # fluid registry
@@ -672,5 +668,3 @@ content {
     }
 
 }
-
-

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -250,7 +250,7 @@ addTooltip(item('deepmoblearning:glitch_fragment'), translatable('nomiceu.toolti
 // Matter
 for (MetadataLivingMatter matter : MetadataManager.livingMatterMetadataList) {
 	// XP is as a Percent of One Level
-	int xpPercent = (matter.xpValue / LabsConfig.advanced.aaEioLinearXp) * 100
+	int xpPercent = (matter.xpValue / LabsConfig.advanced.otherModsLinearXp) * 100
 	if (xpPercent == 100)
 		addTooltip(matter.itemStack, translatable('nomiceu.tooltip.dme.matter.full_level'))
 	else


### PR DESCRIPTION
This PR updates Nomi-Labs to v0.8.11, fixing issues with worlds increasing by multiple ticks at at time, problems with sorting Actually Additions' Crates, and problems with using Thermal Foundation's Tome of Experience.

Fixes #906 (Only made as Labs was updated incorrectly)

Fixes #901
Fixes #900
Fixes #899
Fixes #902
Fixes #898
Fixes #896