### PR TITLE
Unhide Parabolic Flux Coupling

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/thermal.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/thermal.groovy
@@ -20,7 +20,6 @@ removeAndHideItemIgnoreNBT(item('thermalexpansion:device', 9)) // Decoctive Diff
 // Hide Unused Augments
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 352)) // Pyroconvective Loop
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 401)) // Flux Reconstruction
-mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 402)) // Parabolic Flux Coupling
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 448)) // Reagent Recovery
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 656)) // Isentropic Reservoir
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 672)) // Closed Loop Cooling


### PR DESCRIPTION
This PR unhides parabolic flux coupling, so that people can make and use the argument to charge their flux capacitors wirelessly.