### PR TITLE
Make Tier IV Jetpack Hover Mode Stable

### DIFF
--- a/overrides/config/simplyjetpacks-client.cfg
+++ b/overrides/config/simplyjetpacks-client.cfg
@@ -29,7 +29,7 @@
     B:"Enable Fuel HUD"=true
 
     # When enabled, a HUD that displays the states (engine/mode/etc.) of the currently worn jetpack or flux pack will show.
-    B:"Enable State HUD"=true
+    B:"Enable State HUD"=false
 
     # When enabled, switching jetpacks or flux packs on or off, or change their modes will display a status message above the inventory bar.
     B:"Enable State Messages"=true
@@ -56,7 +56,7 @@
     B:"Minimal Fuel HUD"=false
 
     # When enabled, the HUD will display even when the chat window is opened.
-    B:"Show HUD while chatting"=true
+    B:"Show HUD while chatting"=false
 }
 
 

--- a/overrides/config/simplyjetpacks-client.cfg
+++ b/overrides/config/simplyjetpacks-client.cfg
@@ -29,7 +29,7 @@
     B:"Enable Fuel HUD"=true
 
     # When enabled, a HUD that displays the states (engine/mode/etc.) of the currently worn jetpack or flux pack will show.
-    B:"Enable State HUD"=false
+    B:"Enable State HUD"=true
 
     # When enabled, switching jetpacks or flux packs on or off, or change their modes will display a status message above the inventory bar.
     B:"Enable State Messages"=true

--- a/overrides/config/simplyjetpacks.cfg
+++ b/overrides/config/simplyjetpacks.cfg
@@ -593,7 +593,7 @@
     D:"Vertical Speed"=0.8
 
     # The maximum vertical speed of this jetpack when slowly descending in hover mode.
-    D:"Vertical Speed (Hover Mode / Slow Descent)"=0.005
+    D:"Vertical Speed (Hover Mode / Slow Descent)"=0
 
     # The maximum vertical speed of this jetpack when flying in hover mode.
     D:"Vertical Speed (Hover Mode)"=0.4
@@ -653,7 +653,7 @@
     D:"Vertical Speed"=0.8
 
     # The maximum vertical speed of this jetpack when slowly descending in hover mode.
-    D:"Vertical Speed (Hover Mode / Slow Descent)"=0.005
+    D:"Vertical Speed (Hover Mode / Slow Descent)"=0
 
     # The maximum vertical speed of this jetpack when flying in hover mode.
     D:"Vertical Speed (Hover Mode)"=0.4


### PR DESCRIPTION
Changes Vibrant and Resonant Jetpack (Vibrant being the relevant one) from very slow to zero gradual drop with Vibrant and Resonant jetpacks. This is to fix a major pain point in hard mode where no stable flight is not available until t4½mm because of Soul Binder>Angel Ring needing heads. No balance impact but major QoL when building, especially in the void.

Removes redundant status display of engine and hover status. Hover is obvious in use and engine on/off is not a functional keybind by default (G but doesn't work due to a conflict).

If you know what you're doing then Angel Ring is still a relevant goal because it can be stacked with a jetpack to increase speed.