### PR TITLE
Fix Sleeping in Void Dimension not Resetting Weather

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -720,7 +720,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5624443,
+      "fileID": 5634690,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Lans to v0.8.12, which fixes sleeping in void dimension not resetting the weather.

This release also adds a method to copy `ChangeRecipeBuilder`(s), which have been used to cleanup the crystal autoclave changes in `ae2/items.groovy`.

Fixes #913