### PR TITLE
Fix Occasional Errors with GrS

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -655,7 +655,7 @@
     },
     {
       "projectID": 687577,
-      "fileID": 5562296,
+      "fileID": 5635093,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates GroovyScript to v1.1.3. This accomplishes two main goals:
- Fixing occasional GrS errors on some specific environments, due to Jabel not compiling `record`(s) correctly into `class`(es).
- Fixing issues with running Nomi-CEu on Cleanroom, when combined with the latest Fugue build