### PR TITLE
Add Tooltips for the Inverter Card

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -121,6 +121,9 @@ addTooltip(item('appliedenergistics2:material', 27), translatable('nomiceu.toolt
 // Redstone Card
 addTooltip(item('appliedenergistics2:material', 26), translatable('nomiceu.tooltip.ae2.acceleration_card'))
 
+// Inverter Card
+addTooltip(item('appliedenergistics2:material', 31), translatable("nomiceu.tooltip.ae2.inverter_card"))
+
 // Sticky Card
 addTooltip(item('appliedenergistics2:material', 61), translatable('nomiceu.tooltip.ae2.sticky_card'))
 

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -59,6 +59,7 @@ nomiceu.tooltip.ae2.crafting_storage=§ePlace this into a Crafting Grid to recyc
 nomiceu.tooltip.ae2.storage_cell=§eShift Right Click whilst holding this to recycle it!§r
 nomiceu.tooltip.ae2.quartz_knife=§eRight Click on placed ME parts to rename them... for free!§r
 nomiceu.tooltip.ae2.p2p_reset_me_shapeless=§5Reset P2Ps back to ME P2Ps!§r
+nomiceu.tooltip.ae2.inverter_card=§eInverts the Logic of a ME Machine.§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.1=§bAn even faster version of the Acceleration Card!§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.2=§cOnly Works in ME IO Ports.§r
 


### PR DESCRIPTION
This PR adds the missing tooltip for the AE2 Inverter Card.