### PR TITLE
Fix GroovyScript Error Caused by #927

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/aa.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/aa.groovy
@@ -102,6 +102,12 @@ class IngredientMCEmpower implements IIngredient {
 
 	@Override
 	boolean test(ItemStack itemStack) { return ing.apply(itemStack) }
+
+	@Override
+	String getMark() { return null }
+
+	@Override
+	void setMark(String s) {}
 }
 
 mods.actuallyadditions.empowerer.streamRecipes()


### PR DESCRIPTION
This PR simply fixes the GrS error caused by #927, due to the test instance and code checking tools running on GrS 1.1.2.

Fixes #929