### PR TITLE
Add Tooltip Warnings for Various AE2 Items

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -238,6 +238,20 @@ for (ItemStack knife : [item('appliedenergistics2:nether_quartz_cutting_knife'),
 	addTooltip(knife, translatable('nomiceu.tooltip.ae2.quartz_knife'))
 }
 
+// Buses Warning
+List<ItemStack> buses = [
+	item('appliedenergistics2:part', 240), // ME Import Buses
+	item('appliedenergistics2:part', 241), // ME Fluid Import Buses
+	item('appliedenergistics2:part', 260), // ME Export Buses
+	item('appliedenergistics2:part', 261), // ME Fluid Export Buses
+]
+for (var bus : buses) {
+	addTooltip(bus, [translatable("nomiceu.tooltip.ae2.buses.warning")])
+}
+
+// Storage Exposer Warning
+addTooltip(item('nae2:exposer'), [translatableEmpty(), translatable("nomiceu.tooltip.ae2.storage_exposer.warning")])
+
 /* Dimensional Edibles */
 
 // Island Cake

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -62,6 +62,9 @@ nomiceu.tooltip.ae2.p2p_reset_me_shapeless=§5Reset P2Ps back to ME P2Ps!§r
 nomiceu.tooltip.ae2.inverter_card=§eInverts the Logic of a ME Machine.§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.1=§bAn even faster version of the Acceleration Card!§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.2=§cOnly Works in ME IO Ports.§r
+nomiceu.tooltip.ae2.buses.warning=§cMay Cause TPS Lag if used Excessively! Use Interfaces Instead!§r
+nomiceu.tooltip.ae2.storage_exposer.warning=§cMay Cause TPS Lag if used on Big Networks without Filters!§r
+
 
 # Dimensional Edibles
 nomiceu.tooltip.dimensionaledibles.island_cake.1=§aUsed by Server Owners to send FTB Teams and Individuals to their Personal Islands!§r

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -62,8 +62,8 @@ nomiceu.tooltip.ae2.p2p_reset_me_shapeless=§5Reset P2Ps back to ME P2Ps!§r
 nomiceu.tooltip.ae2.inverter_card=§eInverts the Logic of a ME Machine.§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.1=§bAn even faster version of the Acceleration Card!§r
 nomiceu.tooltip.ae2.hyper_acceleration_card.2=§cOnly Works in ME IO Ports.§r
-nomiceu.tooltip.ae2.buses.warning=§cMay Cause TPS Lag if used Excessively! Use Interfaces Instead!§r
-nomiceu.tooltip.ae2.storage_exposer.warning=§cMay Cause TPS Lag if used on Big Networks without Filters!§r
+nomiceu.tooltip.ae2.buses.warning=§cMay cause TPS lag if used excessively! Use Interfaces instead!§r
+nomiceu.tooltip.ae2.storage_exposer.warning=§cMay cause TPS lag if used on big networks without Filters!§r
 
 
 # Dimensional Edibles

--- a/overrides/resources/nae2/lang/en_us.lang
+++ b/overrides/resources/nae2/lang/en_us.lang
@@ -1,0 +1,1 @@
+nae2.storage_cell_void.warning.1=§cVoids EVERYTHING!§r


### PR DESCRIPTION
This PR simply adds tooltip warnings for:
- Storage Exposer
- ME Input & Export Buses

This PR also makes the tooltip warnings for the Void Storage Cells red.