### PR TITLE
Fix BQu Detection of Fluids with Stacked Fluid Containers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -720,7 +720,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5646804,
+      "fileID": 5655688,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi-Labs to v0.8.15, which fixes an issue with Better Questing not detecting fluids in Stacked Fluid Containers.

Fixes #938