### PR TITLE
Format 'Infinite' Potion Effects as **/**

### DIFF
--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -783,7 +783,7 @@ general {
 
     misc {
         # Always displays the actual potion duration instead of `**:**`
-        B:"Accurate Potion Duration"=true
+        B:"Accurate Potion Duration"=false
 
         # Always returns the player to the main menu when quitting the game
         B:"Always Return to Main Menu"=false


### PR DESCRIPTION
This PR disables UT's 'accurate potion effects tweaks', once again formatting 'infinite' effects as `**/**`.