### PR TITLE
Actually Make XP Bottles Drop 25 XP

### DIFF
--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -639,7 +639,7 @@ general {
 
         # Sets the amount of experience spawned by bottles o' enchanting
         # -1 for vanilla default
-        I:"XP Bottle Amount"=-1
+        I:"XP Bottle Amount"=25
 
         "attack cooldown" {
             # Disables the 1.9 combat update attack cooldown


### PR DESCRIPTION
This PR actually makes XP Bottles drop 25 XP consistently, as the tooltip claims.