### PR TITLE
Add a FPS Impact Warning to EIO Facades

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -337,6 +337,18 @@ for (ItemStack stack in Common.eioGlasses) {
 	addTooltip(stack, translatable('nomiceu.tooltip.eio.glass.dye'))
 }
 
+// Facades
+List<ItemStack> facades = [
+	item('enderio:item_conduit_facade'),
+	item('enderio:item_conduit_facade', 1),
+	item('enderio:item_conduit_facade', 2),
+	item('enderio:item_conduit_facade', 3),
+]
+
+for (ItemStack facade : facades) {
+	addTooltip(facade, [translatableEmpty(), translatable("nomiceu.tooltip.eio.facade")])
+}
+
 /* Project Red */
 
 // Transmission Wire

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -101,6 +101,7 @@ nomiceu.tooltip.gregtech.facade.2=§3They craft into different amounts based on 
 nomiceu.tooltip.eio.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r
 nomiceu.tooltip.eio.glass.dye=Can be §bDyed§r!
 nomiceu.tooltip.eio.liquid_xp=§e20L = 1XP, 500L = 1 XP Level!§r
+nomiceu.tooltip.eio.facade=§cMay cause FPS lag if used excessively!§r
 
 # Project Red
 nomiceu.tooltip.projectred.wire=§eFor use with ProjectRed.§r


### PR DESCRIPTION
This PR simply adds a tooltip to EIO facades, warning of FPS lag if used excessively.