### PR TITLE
Hide BQu Loot Boxes from JEI

### DIFF
--- a/overrides/config/betterquesting.cfg
+++ b/overrides/config/betterquesting.cfg
@@ -8,6 +8,9 @@ client {
 general {
     # If true, then when you click on Claim all, a warning dialog will be displayed [default: true]
     B:"Claim all requires confirmation"=false
+
+    # The default visibility value used when creating quests [default: NORMAL]
+    S:"Default Quest Visibility"=ALWAYS
     B:"Experimental Dirty Mode"=true
     B:"Hide Updates"=false
 
@@ -27,11 +30,20 @@ general {
     # Increases or decreases the scrolling speed [range: 0.0 ~ 10.0, default: 1.0]
     S:"Scroll Speed Multiplier"=1.0
 
+    # If true, skip the home GUI and open quests at startup. This property will be changed by the mod itself. [default: false]
+    B:"Skip Home"=true
+
+    # If true, then the player will spawn with a Quest Book when they first join the world [default: true]
+    B:"Spawn with Quest Book"=true
+
     # The current questing theme [default: betterquesting:light]
     S:Theme=bq_standard:dark
 
     # Jumps the user to the last opened quest [default: true]
     B:"Use Quest Bookmark"=true
+
+    # If view mode enabled, User can view all quests [default: false]
+    B:"View mode"=true
 
     # Zoom in on cursor. If false, zooms in on center of screen. [default: true]
     B:"Zoom In on Cursor"=true

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -1,4 +1,5 @@
 import com.nomiceu.nomilabs.util.LabsModeHelper
+import net.minecraft.item.ItemStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.*
 
@@ -19,6 +20,20 @@ removeAndHideItemIgnoreNBT(item('thermalexpansion:device', 8)) // Insightful Con
 if (LabsModeHelper.expert) {
 	mods.jei.ingredient.removeAndHide(item('nomilabs:impossiblerealmdata'))
 }
+
+// Better Questing
+List<ItemStack> lootBoxes = [
+	item('bq_standard:loot_chest'),
+	item('bq_standard:loot_chest', 25),
+	item('bq_standard:loot_chest', 50),
+	item('bq_standard:loot_chest', 75),
+	item('bq_standard:loot_chest', 100),
+	item('bq_standard:loot_chest', 101),
+	item('bq_standard:loot_chest', 102),
+	item('bq_standard:loot_chest', 103),
+	item('bq_standard:loot_chest', 104),
+]
+lootBoxes.forEach { removeAndHideItemIgnoreNBT(it) }
 
 // Modded Buckets
 hideItemIgnoreNBT(item('forge:bucketfilled'))


### PR DESCRIPTION
This PR hides Loot Boxes from JEI, which are unused and useless.

This PR also changes the BQ Config such that new quests are created with visibility 'ALWAYS'.