### PR TITLE
Replace Forgelin and Librarian Lib with Forked Versions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -260,11 +260,6 @@
       "required": true
     },
     {
-      "projectID": 248453,
-      "fileID": 2785465,
-      "required": true
-    },
-    {
       "projectID": 248787,
       "fileID": 2987247,
       "required": true
@@ -309,11 +304,6 @@
     {
       "projectID": 252848,
       "fileID": 2893527,
-      "required": true
-    },
-    {
-      "projectID": 252910,
-      "fileID": 3041340,
       "required": true
     },
     {
@@ -582,6 +572,11 @@
       "required": true
     },
     {
+      "projectID": 456403,
+      "fileID": 5624708,
+      "required": true
+    },
+    {
       "projectID": 460609,
       "fileID": 5257348,
       "required": true
@@ -736,6 +731,11 @@
     {
       "projectID": 951064,
       "fileID": 5002181,
+      "required": true
+    },
+    {
+      "projectID": 1058274,
+      "fileID": 5531643,
       "required": true
     }
   ]


### PR DESCRIPTION
This PR replaces Forgelin with Forgelin Continuous, and Librarian Lib with Librarian Lib Continuous.

This fixes an issue with Kotlin version conflicts, causing a crash when Essentials was installed.

Fixes #969