### PR TITLE
Remove Checkout of Tag in CF and GitHub Deployment

### DIFF
--- a/.github/workflows/deploycf.yml
+++ b/.github/workflows/deploycf.yml
@@ -10,7 +10,7 @@ on:
         description: The Release Type. This is the formatted version.
         required: true
         type: string
-        
+
 jobs:
   deployCF:
     name: Deploy to CurseForge (${{ inputs.tag }})
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
 
       - name: Restore NPM Cached Files
         uses: actions/cache@v4
@@ -60,7 +59,7 @@ jobs:
         with:
           name: Built Pack
           path: ./build/
-          
+
       - name: Deploy to CurseForge
         env:
           CURSEFORGE_PROJECT_ID: ${{ secrets.CURSEFORGE_PROJECT_ID }}

--- a/.github/workflows/deploygh.yml
+++ b/.github/workflows/deploygh.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
 
       - name: Restore NPM Cached Files
         uses: actions/cache@v4


### PR DESCRIPTION
This PR stops Cf and GH Deployments from checking out the provided tag.

This is unnecessary as the pack was already built (with build-pack) in the provided tag's environment, and checking it out here will not capture any state of the pack except for the buildscripts, which should not have their state captured.