### PR TITLE
Fix Issues with Searching Tooltips in JEI

### DIFF
--- a/overrides/config/Universal Tweaks - Tweaks.cfg
+++ b/overrides/config/Universal Tweaks - Tweaks.cfg
@@ -1197,7 +1197,7 @@ general {
         B:"Fast World Loading"=false
 
         # Fixes slow background startup edge case caused by checking tooltips during the loading process
-        B:"Faster Background Startup"=true
+        B:"Faster Background Startup"=false
 
         # Improves the speed of switching languages in the Language GUI
         B:"Improve Language Switching Speed"=true


### PR DESCRIPTION
This PR simply disables UT's 'Faster Background Startup', which fixes the searching of tooltips in JEI. 

Originally reported and solution proposed in https://github.com/CleanroomMC/HadEnoughItems/issues/42.