### PR TITLE
Make Fork PR Build Only Run on Certain PRs

### DIFF
--- a/.github/workflows/forkprbuildpack.yml
+++ b/.github/workflows/forkprbuildpack.yml
@@ -3,7 +3,7 @@
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information!
 
 # Actions taken to reduce risk:
-# This workflow is only started when the workflow run is approved (GitHub Settings), and when the deployment to `forkprbuildpack` is approved (by admin-devs)
+# This workflow is only started if a PR has the 'fork-build' label, and when the deployment to `forkprbuildpack` is approved (by admin-devs)
 # Only the CFCORE_API_TOKEN secret is accessed, meaning it is the only one revealed, meaning that the other secrets cannot be used by nodejs tools
 # GITHUB_TOKEN permissions are set to read
 
@@ -11,6 +11,9 @@ name: "[NOT CALLABLE] Fork PR Build Pack"
 
 on:
   pull_request_target:
+    types:
+      - synchronize
+      - labeled
     paths-ignore:
       - "README.md"
 
@@ -29,8 +32,8 @@ env:
 
 jobs:
   setup:
-    # Only continue if we are in base Nomi-CEu Repo and pull request is from fork
-    if: "${{ github.repository_owner == 'Nomi-CEu' && github.event.pull_request.head.repo.owner.login != 'Nomi-CEu' }}"
+    # Only continue if we are in base Nomi-CEu Repo, pull request is from fork and pr has fork-build label
+    if: "${{ github.repository_owner == 'Nomi-CEu' && github.event.pull_request.head.repo.owner.login != 'Nomi-CEu' && contains(github.event.pull_request.labels.*.name, 'fork-build') }}"
     name: Setup (${{ github.event.pull_request.head.sha }})
     runs-on: ubuntu-latest
     environment: fork-pr-build-pack


### PR DESCRIPTION
This PR prevents Fork PR Builds from running on PRs without the 'fork-build' label.

This reduces annoyance by:
- Removing the need for deployments to be constantly approved
- Allows workflows on fork PRs to be run without direct approval, so that the 'checks' workflow can run normally