### PR TITLE
Make Changelog Once for Seperate Builds

### DIFF
--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -271,6 +271,7 @@ jobs:
         run: npm ci
 
       - name: Download Changelog Artifacts
+        if: ${{ !inputs.skip_changelog }}
         uses: actions/download-artifact@v4
         with:
           name: Changelogs
@@ -334,6 +335,7 @@ jobs:
         run: npm ci
 
       - name: Download Changelog Artifacts
+        if: ${{ !inputs.skip_changelog }}
         uses: actions/download-artifact@v4
         with:
           name: Changelogs
@@ -388,6 +390,7 @@ jobs:
         run: npm ci
 
       - name: Download Changelog Artifacts
+        if: ${{ !inputs.skip_changelog }}
         uses: actions/download-artifact@v4
         with:
           name: Changelogs

--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -221,6 +221,12 @@ jobs:
         if: ${{ !inputs.skip_changelog }}
         working-directory: ./tools
         run: npm run gulp buildChangelog
+        env:
+          CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
+          CHANGELOG_BRANCH: ${{ inputs.changelog_branch }}
+          CHANGELOG_URL: ${{ inputs.changelog_url }}
+          CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
+          COMPARE_TAG: ${{ inputs.compare_tag }}
 
       - name: Upload Changelogs
         if: ${{ !inputs.skip_changelog }}
@@ -264,24 +270,11 @@ jobs:
         working-directory: ./tools
         run: npm ci
 
-      - name: Check Environmental Variables
-        working-directory: ./tools
-        run: npm run gulp check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURSEFORGE_PROJECT_ID: ${{ secrets.CURSEFORGE_PROJECT_ID }}
-          CURSEFORGE_API_TOKEN: ${{ secrets.CURSEFORGE_API_TOKEN }}
-          CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-
       - name: Build Client
         working-directory: ./tools
         run: npm run gulp buildClient
         env:
           CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-          CHANGELOG_BRANCH: ${{ inputs.changelog_branch }}
-          CHANGELOG_URL: ${{ inputs.changelog_url }}
-          CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
-          COMPARE_TAG: ${{ inputs.compare_tag }}
           MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Client Zip
@@ -334,24 +327,11 @@ jobs:
         working-directory: ./tools
         run: npm ci
 
-      - name: Check Environmental Variables
-        working-directory: ./tools
-        run: npm run gulp check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURSEFORGE_PROJECT_ID: ${{ secrets.CURSEFORGE_PROJECT_ID }}
-          CURSEFORGE_API_TOKEN: ${{ secrets.CURSEFORGE_API_TOKEN }}
-          CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-
       - name: Build Server
         working-directory: ./tools
         run: npm run gulp buildServer
         env:
           CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-          CHANGELOG_BRANCH: ${{ inputs.changelog_branch }}
-          CHANGELOG_URL: ${{ inputs.changelog_url }}
-          CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
-          COMPARE_TAG: ${{ inputs.compare_tag }}
           MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Server Zip
@@ -395,24 +375,11 @@ jobs:
         working-directory: ./tools
         run: npm ci
 
-      - name: Check Environmental Variables
-        working-directory: ./tools
-        run: npm run gulp check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURSEFORGE_PROJECT_ID: ${{ secrets.CURSEFORGE_PROJECT_ID }}
-          CURSEFORGE_API_TOKEN: ${{ secrets.CURSEFORGE_API_TOKEN }}
-          CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-
       - name: Build Lang
         working-directory: ./tools
         run: npm run gulp buildLang
         env:
           CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
-          CHANGELOG_BRANCH: ${{ inputs.changelog_branch }}
-          CHANGELOG_URL: ${{ inputs.changelog_url }}
-          CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
-          COMPARE_TAG: ${{ inputs.compare_tag }}
           MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Lang Zip

--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -167,7 +167,7 @@ jobs:
           compression-level: 0
 
   makeNames:
-    name: Make Artifact Names (${{ inputs.tag }})
+    name: Make Artifact Names and Changelogs (${{ inputs.tag }})
     runs-on: ubuntu-latest
     if: ${{ inputs.separate_upload }}
     outputs:
@@ -216,6 +216,20 @@ jobs:
         id: artifactNames
         working-directory: ./tools
         run: npm run gulp makeArtifactNames
+
+      - name: Make Changelogs
+        if: ${{ !inputs.skip_changelog }}
+        working-directory: ./tools
+        run: npm run gulp buildChangelog
+
+      - name: Upload Changelogs
+        if: ${{ !inputs.skip_changelog }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Changelogs
+          path: ./build/*.md
+          if-no-files-found: error
+          compression-level: 9
 
   buildClient:
     name: Build Pack Client (${{ inputs.tag }})
@@ -268,6 +282,7 @@ jobs:
           CHANGELOG_URL: ${{ inputs.changelog_url }}
           CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
           COMPARE_TAG: ${{ inputs.compare_tag }}
+          MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Client Zip
         uses: actions/upload-artifact@v4
@@ -337,6 +352,7 @@ jobs:
           CHANGELOG_URL: ${{ inputs.changelog_url }}
           CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
           COMPARE_TAG: ${{ inputs.compare_tag }}
+          MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Server Zip
         uses: actions/upload-artifact@v4
@@ -388,7 +404,7 @@ jobs:
           CURSEFORGE_API_TOKEN: ${{ secrets.CURSEFORGE_API_TOKEN }}
           CFCORE_API_TOKEN: ${{ secrets.CFCORE_API_TOKEN }}
 
-      - name: Build Lang and Changelogs
+      - name: Build Lang
         working-directory: ./tools
         run: npm run gulp buildLang
         env:
@@ -397,20 +413,12 @@ jobs:
           CHANGELOG_URL: ${{ inputs.changelog_url }}
           CHANGELOG_CF_URL: ${{ inputs.changelog_cf_url }}
           COMPARE_TAG: ${{ inputs.compare_tag }}
+          MADE_CHANGELOG: true # Changelog Already Exists
 
       - name: Upload Lang Zip
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.makeNames.outputs.lang }}
           path: ./build/lang/**/*
-          if-no-files-found: error
-          compression-level: 9
-
-      - name: Upload Changelogs
-        if: ${{ !inputs.skip_changelog }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: Changelogs
-          path: ./build/*.md
           if-no-files-found: error
           compression-level: 9

--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -270,6 +270,12 @@ jobs:
         working-directory: ./tools
         run: npm ci
 
+      - name: Download Changelog Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Changelogs
+          path: ./build/
+
       - name: Build Client
         working-directory: ./tools
         run: npm run gulp buildClient
@@ -327,6 +333,12 @@ jobs:
         working-directory: ./tools
         run: npm ci
 
+      - name: Download Changelog Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Changelogs
+          path: ./build/
+
       - name: Build Server
         working-directory: ./tools
         run: npm run gulp buildServer
@@ -374,6 +386,12 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         working-directory: ./tools
         run: npm ci
+
+      - name: Download Changelog Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Changelogs
+          path: ./build/
 
       - name: Build Lang
         working-directory: ./tools

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - test_buildscript*
+      - test-buildscript*
       - dev/*
     paths-ignore:
       - "README.md"

--- a/.github/workflows/testbuildpack.yml
+++ b/.github/workflows/testbuildpack.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - test_buildscript*
+      - test-buildscript*
       - dev/*
     paths-ignore:
       - "README.md"

--- a/.github/workflows/testcommits.yml
+++ b/.github/workflows/testcommits.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - test_buildscript*
+      - test-buildscript*
 
 jobs:
   testCommits:

--- a/tools/gulpfile.ts
+++ b/tools/gulpfile.ts
@@ -14,7 +14,7 @@ export const updateFilesAll = transformFiles.updateAll;
 import * as changelog from "./tasks/changelog/index.ts";
 export const createChangelog = changelog.createRootChangelog;
 
-import sharedTasks from "./tasks/shared/index.ts";
+import * as sharedTasks from "./tasks/shared/index.ts";
 import clientTasks from "./tasks/client/index.ts";
 import serverTasks from "./tasks/server/index.ts";
 import langTasks from "./tasks/lang/index.ts";
@@ -22,23 +22,27 @@ import mmcTasks from "./tasks/mmc/index.ts";
 import * as modTasks from "./tasks/misc/downloadMods.ts";
 
 export const buildClient = gulp.series(
-	sharedTasks,
+	sharedTasks.default,
 	clientTasks,
 	pruneCacheTask,
 );
 export const buildServer = gulp.series(
-	gulp.parallel(sharedTasks, modTasks.downloadSharedAndServer),
+	gulp.parallel(sharedTasks.default, modTasks.downloadSharedAndServer),
 	serverTasks,
 	pruneCacheTask,
 );
-export const buildLang = gulp.series(sharedTasks, langTasks, pruneCacheTask);
+export const buildLang = gulp.series(
+	sharedTasks.default,
+	langTasks,
+	pruneCacheTask,
+);
 export const buildMMC = gulp.series(
-	gulp.parallel(sharedTasks, modTasks.downloadSharedAndClient),
+	gulp.parallel(sharedTasks.default, modTasks.downloadSharedAndClient),
 	mmcTasks,
 	pruneCacheTask,
 );
 export const buildAll = gulp.series(
-	sharedTasks,
+	sharedTasks.default,
 	gulp.parallel(
 		clientTasks,
 		langTasks,
@@ -46,6 +50,7 @@ export const buildAll = gulp.series(
 	),
 	pruneCacheTask,
 );
+export const buildChangelog = sharedTasks.buildChangelog;
 
 import checkTasks from "./tasks/checks/index.ts";
 export const check = gulp.series(checkTasks);

--- a/tools/tasks/shared/index.ts
+++ b/tools/tasks/shared/index.ts
@@ -15,8 +15,9 @@ import { FileDef } from "#types/fileDef.ts";
 import {
 	downloadFileDef,
 	downloadOrRetrieveFileDef,
-	isEnvVariableSet, promiseStream,
-	shouldSkipChangelog
+	isEnvVariableSet,
+	promiseStream,
+	shouldSkipChangelog,
 } from "#utils/util.ts";
 import transformVersion from "./transformVersion.ts";
 import { createBuildChangelog } from "../changelog/index.ts";
@@ -114,6 +115,17 @@ async function fetchExternalDependencies() {
 async function fetchOrMakeChangelog() {
 	if (shouldSkipChangelog()) return;
 
+	if (!isEnvVariableSet("MADE_CHANGELOG")) return false;
+
+	let made = false;
+	try {
+		made = JSON.parse((process.env.MADE_CHANGELOG ?? "false").toLowerCase());
+	} catch (err) {
+		throw new Error("Made Changelog Env Variable set to Invalid Value.");
+	}
+
+	if (made) logInfo("Already Made Changelogs...");
+
 	if (
 		isEnvVariableSet("CHANGELOG_URL") &&
 		isEnvVariableSet("CHANGELOG_CF_URL")
@@ -195,4 +207,10 @@ export default gulp.series(
 	updateBuildLabsVersion,
 	transformVersion,
 	transformQuestBook,
+);
+
+export const buildChangelog = gulp.series(
+	sharedCleanUp,
+	createSharedDirs,
+	fetchOrMakeChangelog,
 );

--- a/tools/tasks/shared/index.ts
+++ b/tools/tasks/shared/index.ts
@@ -115,16 +115,19 @@ async function fetchExternalDependencies() {
 async function fetchOrMakeChangelog() {
 	if (shouldSkipChangelog()) return;
 
-	if (!isEnvVariableSet("MADE_CHANGELOG")) return false;
+	if (isEnvVariableSet("MADE_CHANGELOG")) {
+		let made = false;
+		try {
+			made = JSON.parse((process.env.MADE_CHANGELOG ?? "false").toLowerCase());
+		} catch (err) {
+			throw new Error("Made Changelog Env Variable set to Invalid Value.");
+		}
 
-	let made = false;
-	try {
-		made = JSON.parse((process.env.MADE_CHANGELOG ?? "false").toLowerCase());
-	} catch (err) {
-		throw new Error("Made Changelog Env Variable set to Invalid Value.");
+		if (made) {
+			logInfo("Already Made Changelogs...");
+			return;
+		}
 	}
-
-	if (made) logInfo("Already Made Changelogs...");
 
 	if (
 		isEnvVariableSet("CHANGELOG_URL") &&


### PR DESCRIPTION
This PR changes the seperate build system, making it so that changelogs are only made once, saving rate limits and processing time.