### PR TITLE
Fix ME Conduit Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/eio.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/eio.groovy
@@ -8,3 +8,11 @@ for (var stack in Common.eioGlasses) {
 	mods.jei.ingredient.hide(new ItemStack(stack.getItem(), 1, Short.MAX_VALUE))
 	mods.jei.ingredient.add(stack.copy())
 }
+
+// ME Conduit - Crafting Table
+crafting.shapedBuilder()
+	.output(item('enderio:item_me_conduit') * 4)
+	.matrix('BBB', 'PPP', 'BBB')
+	.key('B', ore('itemConduitBinder'))
+	.key('P', item('appliedenergistics2:part', 36))
+	.replace().register()

--- a/overrides/scripts/electronics.zs
+++ b/overrides/scripts/electronics.zs
@@ -92,12 +92,6 @@ recipes.addShaped(<enderio:item_redstone_conduit> * 4, [
 	[<metaitem:wireGtSingleRedAlloy>,<metaitem:wireGtSingleRedAlloy>,<metaitem:wireGtSingleRedAlloy>], 
 	[<ore:itemConduitBinder>, <ore:itemConduitBinder>, <ore:itemConduitBinder>]]);
 
-//me conduit - by hand
-recipes.addShaped(<enderio:item_me_conduit> * 4, [
-	[<ore:itemConduitBinder>, <ore:itemConduitBinder>, <ore:itemConduitBinder>], 
-	[<appliedenergistics2:part:36>,<appliedenergistics2:part:36>,<appliedenergistics2:part:36>], 
-	[<ore:itemConduitBinder>, <ore:itemConduitBinder>, <ore:itemConduitBinder>]]);
-
 //redstone conduit - assembler
 assembler.recipeBuilder()
     .inputs([<metaitem:wireGtSingleRedAlloy> * 3, <ore:itemConduitBinder> * 6])


### PR DESCRIPTION
This PR simply fixes the me conduit crafting recipe, which seemed to have a conflict with an invisible recipe. This PR moves it to GrS, and calls `.replace()`.