### PR TITLE
Fix Hand Framing Display Recipes

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/handFraming.groovy
@@ -42,8 +42,8 @@ for (ItemStack stack : items) {
 				.name(recipeName)
 				.output(recipeStack)
 				.matrix(
-					'IT ',
-					'FS ',
+					'ST ',
+					'FI ',
 					'   ')
 				.key('S', item("xtones:zane"))
 				.key('T', trim ? item("extendedcrafting:storage", 4) : IIngredient.EMPTY)


### PR DESCRIPTION
This PR simply fixes the Hand Framing display recipes, which showed the frameable item in the top left instead of the bottom right.