### PR TITLE
Content Clearing Recipes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -715,7 +715,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5785209,
+      "fileID": 5790272,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -715,7 +715,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5784640,
+      "fileID": 5785209,
       "required": true
     },
     {

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -27,26 +27,31 @@ for (def meta : 1..15) {
 }
 
 /* Drawers */
-/* Also voids upgrades, but if we didn't, it would look as if not nmpty */
 // Wooden Type Drawers
 for (def meta : 0..4) {
     nbtClearingRecipe(item('storagedrawers:basicdrawers', meta), {
-        it.tagCompound = transferSubTags(it, 'material')
+        var tag = transferSubTags(it, 'material')
+        it.tagCompound = transferDrawerUpgradeData(it, tag)
     })
+}
+
+var normalClearer = { ItemStack it ->
+    it.tagCompound = transferDrawerUpgradeData(it, null)
 }
 
 // GregTech Drawers
 for (def meta : 0..4) {
-    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta))
-    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta))
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta), normalClearer)
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta), normalClearer)
 }
 
 // Compacting Drawers
-nbtClearingRecipe(item('storagedrawers:compdrawers'))
+nbtClearingRecipe(item('storagedrawers:compdrawers'), normalClearer)
 
 /* Framed Drawer Like */
 def framedClearer = { ItemStack it ->
-    it.tagCompound = transferSubTags(it, 'MatS', 'MatT', 'MatF')
+    var tag = transferSubTags(it, 'MatS', 'MatT', 'MatF')
+    it.tagCompound = transferDrawerUpgradeData(it, tag)
 }
 
 // Framed Drawers

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -3,7 +3,9 @@ import net.minecraft.item.ItemStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.NBTClearingRecipeHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 import static com.nomiceu.nomilabs.groovy.NBTClearingRecipe.CAN_CLEAR_TOOLTIP
+import static com.nomiceu.nomilabs.groovy.NBTClearingRecipe.WARNING_TOOLTIP
 import static gregtech.common.metatileentities.MetaTileEntities.*
 
 // NBT Clearing Recipes
@@ -23,16 +25,24 @@ for (def material : ["wood", "bronze", "steel", "aluminium", "stainless_steel", 
 
 // NC Coolers
 for (def meta : 1..15) {
-    nbtClearingRecipe(item('nuclearcraft:cooler', meta), item('nuclearcraft:cooler'))
+    nbtClearingRecipe(item('nuclearcraft:cooler', meta), item('nuclearcraft:cooler'),
+            translatable('nomiceu.tooltip.nc.nbt_clearing.cooler.can_clear'),
+            translatable('nomiceu.tooltip.nc.nbt_clearing.cooler.warning'))
 }
 
 /* Drawers */
+// Add empty can clear tooltip, as we want to add multiple lines
+var empty = translatableEmpty()
+List<ItemStack> canClearDrawers = []
+
 // Wooden Type Drawers
 for (def meta : 0..4) {
     nbtClearingRecipe(item('storagedrawers:basicdrawers', meta), {
         var tag = transferSubTags(it, 'material')
         it.tagCompound = transferDrawerUpgradeData(it, tag)
-    })
+    }, empty, WARNING_TOOLTIP)
+
+    canClearDrawers.add(item('storagedrawers:basicdrawers', meta))
 }
 
 var normalClearer = { ItemStack it ->
@@ -41,12 +51,18 @@ var normalClearer = { ItemStack it ->
 
 // GregTech Drawers
 for (def meta : 0..4) {
-    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta), normalClearer)
-    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta), normalClearer)
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta), normalClearer,
+            empty, WARNING_TOOLTIP)
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta), normalClearer,
+            empty, WARNING_TOOLTIP)
+
+    canClearDrawers.add(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta))
+    canClearDrawers.add(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta))
 }
 
 // Compacting Drawers
-nbtClearingRecipe(item('storagedrawers:compdrawers'), normalClearer)
+nbtClearingRecipe(item('storagedrawers:compdrawers'), normalClearer, empty, WARNING_TOOLTIP)
+canClearDrawers.add(item('storagedrawers:compdrawers'))
 
 /* Framed Drawer Like */
 def framedClearer = { ItemStack it ->
@@ -56,11 +72,18 @@ def framedClearer = { ItemStack it ->
 
 // Framed Drawers
 for (def meta : 0..4) {
-    nbtClearingRecipe(item('storagedrawers:customdrawers', meta), framedClearer)
+    nbtClearingRecipe(item('storagedrawers:customdrawers', meta), framedClearer, empty, WARNING_TOOLTIP)
+    canClearDrawers.add(item('storagedrawers:customdrawers', meta))
 }
 
 // Framed Compacting Drawers
-nbtClearingRecipe(item('framedcompactdrawers:framed_compact_drawer'), framedClearer)
+nbtClearingRecipe(item('framedcompactdrawers:framed_compact_drawer'), framedClearer, empty, WARNING_TOOLTIP)
+canClearDrawers.add(item('framedcompactdrawers:framed_compact_drawer'))
+
+for (var canClear : canClearDrawers) {
+    addTooltip(canClear, [translatable('nomiceu.tooltip.drawers.nbt_clearing.drawers.can_clear.1'),
+                          translatable('nomiceu.tooltip.drawers.nbt_clearing.drawers.can_clear.2')])
+}
 
 // Thermal Portable Tanks
 nbtClearingRecipe(item('thermalexpansion:tank'), {

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -35,6 +35,12 @@ for (def meta : 0..4) {
     })
 }
 
+// GregTech Drawers
+for (def meta : 0..4) {
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_rubber_wood', meta))
+    nbtClearingRecipe(item('gregtechdrawers:basicdrawers_gregtech_treated_wood', meta))
+}
+
 // Compacting Drawers
 nbtClearingRecipe(item('storagedrawers:compdrawers'))
 

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -27,12 +27,33 @@ for (def meta : 1..15) {
 }
 
 /* Drawers */
+/* Also voids upgrades, but if we didn't, it would look as if not nmpty */
 // Wooden Type Drawers
+for (def meta : 0..4) {
+    nbtClearingRecipe(item('storagedrawers:basicdrawers', meta), {
+        it.tagCompound = transferSubTags(it, 'material')
+    })
+}
 
+// Compacting Drawers
+nbtClearingRecipe(item('storagedrawers:compdrawers'))
+
+/* Framed Drawer Like */
+def framedClearer = { ItemStack it ->
+    it.tagCompound = transferSubTags(it, 'MatS', 'MatT', 'MatF')
+}
+
+// Framed Drawers
+for (def meta : 0..4) {
+    nbtClearingRecipe(item('storagedrawers:customdrawers', meta), framedClearer)
+}
+
+// Framed Compacting Drawers
+nbtClearingRecipe(item('framedcompactdrawers:framed_compact_drawer'), framedClearer)
 
 // Thermal Portable Tanks
 nbtClearingRecipe(item('thermalexpansion:tank'), {
-    transferSubTags(it, 'Creative', 'Level', 'RSControl')
+    it.tagCompound = transferSubTags(it, 'Creative', 'Level', 'RSControl')
 })
 
 // Tooltips for Other Clearable Containers

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -113,5 +113,13 @@ nomiceu.tooltip.labs.hand_framing.top_left=§5Top Left: §oSide§r
 nomiceu.tooltip.labs.hand_framing.top_right=§5Top Right: §oTrim§r
 nomiceu.tooltip.labs.hand_framing.bottom_left=§5Bottom Left: §oFront§r
 
+# NuclearCraft
+nomiceu.tooltip.nc.nbt_clearing.cooler.can_clear=Place in Crafting Grid to §eClear Coolant§r!
+nomiceu.tooltip.nc.nbt_clearing.cooler.warning=§cCoolant Will be Voided!§r
+
+# Storage Drawers, Framed Compacting Drawers & GregTech Drawers
+nomiceu.tooltip.drawers.nbt_clearing.drawers.can_clear.1=Place in Crafting Grid to §eClear Contents§r!
+nomiceu.tooltip.drawers.nbt_clearing.drawers.can_clear.2=Upgrades will be §aKept§r!
+
 # XTones
 nomiceu.tooltip.xtones.lamp=§eRequires a redstone signal to light.§r


### PR DESCRIPTION
Note: Please pretend this PR creates the `nbtClearing` file. The file was accidentally committed, in an incomplete state, to the labs 0.9.1 PR.

This PR adds nbt clearing recipes for the following:
- Shulker Boxes
- GregTech Crates
- NuclearCraft (Non-Active) Coolers (Technically not NBT Clearing)
- Drawers (Wooden, GregTech, Framed, Framed Compacted)
- Thermal Portable Tanks

It adds a tooltip notifying players that these containers can be cleared:
- Super/Quantum Chests/Tanks
- GregTech Drums
- EnderIO Portable Tanks