### PR TITLE
Allow Specifying Co-Authors in Changelog

### DIFF
--- a/tools/tasks/changelog/changelogData.ts
+++ b/tools/tasks/changelog/changelogData.ts
@@ -3,7 +3,7 @@ import {
 	Commit,
 	FixUpInfo,
 	InputReleaseType,
-	ParsedModInfo
+	ParsedModInfo,
 } from "#types/changelogTypes.ts";
 import { getLastGitTag, getTags, isEnvVariableSet } from "#utils/util.ts";
 

--- a/tools/tasks/changelog/changelogData.ts
+++ b/tools/tasks/changelog/changelogData.ts
@@ -1,8 +1,9 @@
 import {
+	AuthorInfo,
 	Commit,
 	FixUpInfo,
 	InputReleaseType,
-	ParsedModInfo,
+	ParsedModInfo
 } from "#types/changelogTypes.ts";
 import { getLastGitTag, getTags, isEnvVariableSet } from "#utils/util.ts";
 
@@ -29,6 +30,9 @@ export default class ChangelogData {
 
 	// Map of project IDs to info text and/or details
 	modInfoList: Map<number, ParsedModInfo>;
+
+	// Map of commit sha to specified coauthors for that commit
+	coAuthorList: Map<string, AuthorInfo[]>;
 
 	/**
 	 * Constructor. Non-Async Inits are performed here.
@@ -70,6 +74,7 @@ export default class ChangelogData {
 		this.combineList = new Map<string, Commit[]>();
 
 		this.modInfoList = new Map<number, ParsedModInfo>();
+		this.coAuthorList = new Map<string, AuthorInfo[]>();
 
 		// Init Tag Sets for Now, so we don't have to deal with nullable params
 		this.tags = new Set<string>();
@@ -116,6 +121,7 @@ export default class ChangelogData {
 		this.combineList = new Map<string, Commit[]>();
 
 		this.modInfoList = new Map<number, ParsedModInfo>();
+		this.coAuthorList = new Map<string, AuthorInfo[]>();
 
 		// Tags list is fine because the 'to' (Target) stays the same
 		// Other Tags list is generated at setup

--- a/tools/tasks/changelog/definitions.ts
+++ b/tools/tasks/changelog/definitions.ts
@@ -41,6 +41,8 @@ export const ignoreKey = "[IGNORE]";
 export const modInfoKey = "[MOD INFO]";
 export const modInfoList = "infos";
 export const priorityKey = "[PRIORITY]";
+export const coAuthorsKey = "[AUTHORS]";
+export const coAuthorsList = "authors";
 
 /* Sub Category Keys */
 // Mode Category Keys

--- a/tools/tasks/changelog/parser.ts
+++ b/tools/tasks/changelog/parser.ts
@@ -8,6 +8,7 @@ import {
 } from "#types/changelogTypes.ts";
 import {
 	categories,
+	coAuthorsKey,
 	combineKey,
 	defaultIndentation,
 	detailsKey,
@@ -18,6 +19,7 @@ import {
 	priorityKey,
 } from "./definitions.ts";
 import {
+	parseCoAuthor,
 	parseCombine,
 	parseDetails,
 	parseExpand,
@@ -110,6 +112,9 @@ export async function parseCommitBody(
 ): Promise<boolean | Ignored> {
 	if (commitBody.includes(modInfoKey))
 		await parseModInfo(commitBody, commitObject);
+
+	if (commitBody.includes(coAuthorsKey))
+		await parseCoAuthor(commitBody, commitObject);
 
 	if (commitBody.includes(expandKey)) {
 		await parseExpand(commitBody, commitObject, parser);

--- a/tools/types/changelogTypes.ts
+++ b/tools/types/changelogTypes.ts
@@ -301,6 +301,11 @@ export interface PriorityInfo {
 	priority: number;
 }
 
+export interface AuthorInfo {
+	name: string;
+	email: string;
+}
+
 export type FixUpMode = "REPLACE" | "ADDITION";
 
 export type InputReleaseType =


### PR DESCRIPTION
This PR allows the specification of Co-Authors in the changelog, via the '[AUTHOR]' tag.
