### PR TITLE
Fix GregTech Facades' Tooltip

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -321,8 +321,7 @@ for (ItemStack prospector in [metaitem('prospector.lv'), metaitem('prospector.hv
 
 // Facades
 addTooltip(metaitem('cover.facade'), [
-	translatable('nomiceu.tooltip.gregtech.facade.1'),
-	translatable('nomiceu.tooltip.gregtech.facade.2'),
+	translatable('nomiceu.tooltip.gregtech.facade')
 ])
 
 /* Ender IO */

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -94,8 +94,7 @@ nomiceu.tooltip.gregtech.prospector.1=§6§lUsage:§r
 nomiceu.tooltip.gregtech.prospector.2=Grid squares = 1 chunk, up is north.
 nomiceu.tooltip.gregtech.prospector.3=Click an ore in the sidebar to isolate it.
 nomiceu.tooltip.gregtech.prospector.4=Use JEI to check the potential vein depth.
-nomiceu.tooltip.gregtech.facade.1=§3GTCEu facades can be made from most non-tile-entities.§r
-nomiceu.tooltip.gregtech.facade.2=§3They craft into different amounts based on the metal used!§r
+nomiceu.tooltip.gregtech.facade=§3GTCEu facades can be made from most non-tile-entities.§r
 
 # Ender IO
 nomiceu.tooltip.eio.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r


### PR DESCRIPTION
This PR fixes the tooltips of GT Facades, as they can only be crafted with Iron Plates, not any other metal.