### PR TITLE
Advanced Rocketry Tank Improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -715,7 +715,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5790272,
+      "fileID": 5793270,
       "required": true
     },
     {

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -8,6 +8,12 @@ import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.*
 // AR
 mods.jei.ingredient.removeAndHide(item('advancedrocketry:crystal:*')) // Random Crystal Blocks
 
+removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketrocketfuel'))
+removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketnitrogen'))
+removeAndHideItemIgnoreNBT(item('advancedrocketry:buckethydrogen'))
+removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketoxygen'))
+removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketenrichedlava'))
+
 // Armor Plus
 mods.jei.ingredient.removeAndHide(item('armorplus:block_melting_obsidian')) // Null Texture Item
 


### PR DESCRIPTION
This PR simply removes Advanced Rocketry's tanks from JEI, which are unobtainable, and do not serve any purpose.

To make them truly unobtainable, Advanced Rocketry no longer turns certain collected fluids (Oxygen, Hydrogen, etc.) with buckets turning into AR Tanks.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/276