### PR TITLE
Fix Airtight Seal Recipes

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/advancedRocketry.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/advancedRocketry.groovy
@@ -4,50 +4,61 @@ import net.minecraft.item.ItemStack
 
 import static gregtech.api.GTValues.*
 
-// Add Airtight Seal Recipes
+/* Airtight Seal Recipes */
+// Industrial Rebreather Kit -> Airtight Seal
+mods.enderio.enchanter.recipeBuilder()
+	.enchantment(enchantment('advancedrocketry:spacebreathing'))
+	.input(item('nomilabs:industrial_rebreather_kit'))
+	.amountPerLevel(1)
+	.xpCostMultiplier(3) // 27 Levels, 15 Lapis
+	.register()
+
+// Recipes for Industrial Rebreather Kit
 int airtightId = Enchantment.getEnchantmentID(enchantment('advancedrocketry:spacebreathing'))
 ItemStack airtight = item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) airtightId, 'lvl': (short) 1]]])
 
 if (LabsModeHelper.normal) {
 	mods.gregtech.assembler.recipeBuilder()
 		.inputs(
-			ore('foilAluminium') * 64,
-			metaitem('duct_tape') * 32,
-			item('nomilabs:cloth') * 16,
-			metaitem('carbon.mesh') * 8,
-			metaitem('fluid.regulator.hv') * 4,
-			metaitem('gas_collector.hv'),
+			ore('foilAluminium') * 32,
+			metaitem('duct_tape') * 16,
+			item('nomilabs:cloth') * 8,
+			metaitem('carbon.mesh') * 4,
+			metaitem('fluid.regulator.hv'),
+			metaitem('gas_collector.mv'),
 			item('advancedrocketry:pressuretank', 1), // Normal Pressure Tank
-			item('advancedrocketry:pressuretank', 1),
-			item('advancedrocketry:pressuretank', 1),
 		).fluidInputs(fluid('rubber') * 1296)
-		.outputs(airtight * 4)
+		.outputs(item('nomilabs:industrial_rebreather_kit'))
 		.duration(500).EUt(VA[HV])
 		.buildAndRegister()
 } else {
-	int respirationId = Enchantment.getEnchantmentID(enchantment('minecraft:respiration'))
-	int holdingId = Enchantment.getEnchantmentID(enchantment('cofhcore:holding'))
+	ItemStack respiration = item('minecraft:enchanted_book')
+	ItemStack holding = respiration.copy()
+
+	respiration.addEnchantment(enchantment('minecraft:respiration'), 1)
+	holding.addEnchantment(enchantment('cofhcore:holding'), 1)
+
 	mods.extendedcrafting.table_crafting.shapedBuilder()
 		.tierAdvanced()
-		.output(airtight * 4)
+		.output(item('nomilabs:industrial_rebreather_kit'))
 		.matrix(
 			'RMCMR',
-			'TPZPT',
-			'FADAF',
-			'TPYPT',
+			'TAZAT',
+			'FDPDF',
+			'TAYAT',
 			'RXBXR',
 		)
-		.key('R', ore('ringRubber'))
+		.key('R', ore('ringStyreneButadieneRubber'))
 		.key('M', metaitem('carbon.mesh'))
-		.key('C', metaitem('gas_collector.hv'))
+		.key('C', metaitem('gas_collector.mv'))
 		.key('T', ore('plateDoubleTitanium'))
 		.key('P', item('advancedrocketry:pressuretank', 1)) // Normal Pressure Tank
-		.key('Z', item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) respirationId, 'lvl': (short) 3]]])) // Respiration 3
+		.key('Z', respiration)
 		.key('F', metaitem('fluid.regulator.ev'))
-		.key('A', metaitem('pipeNormalFluidPolytetrafluoroethylene'))
+		.key('A', metaitem('pipeSmallFluidPolytetrafluoroethylene'))
 		.key('D', ore('dustQuicklime'))
-		.key('Y', item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) holdingId, 'lvl': (short) 4]]])) // Holding 4
-		.key('B', metaitem('chemical_reactor.hv'))
+		.key('Y', holding)
+		.key('B', metaitem('chemical_reactor.mv'))
 		.key('X', metaitem('duct_tape'))
 		.register()
 }


### PR DESCRIPTION
This PR fixes Airtight Seal recipes, fixing issues due to Enchantment Books not stacking.

Fixes #990

## Details: (Recipes & Texture of IRK made by @Doniazade)
Airtight Seal Book is now made in the Dark Steel Enchanter, with 27 XP Levels and 15 Lapis per book. The item used to create it is the Industrial Rebreather Kit (IRK). One is required per book.

The recipes for the IRK are as follows:
### Normal Mode:
- 32x Aluminium Foil
- 16x Duct Tape
- 8x Cloth
- 4x Carbon Mesh
- 1x Fluid Regulator (HV)
- 1x Gas Collector (MV)
- 1x Normal Pressure Tank

In Assembler, 480 EU/t for 25 Seconds

![image](https://github.com/user-attachments/assets/f8e03437-9169-4cc4-ac43-f58a46c220cf)

### Expert Mode:
- 4x Styrene-Butadiene Rubber Rings
- 2x Carbon Fiber Mesh
- 2x Duct Tape
- 1x Gas Collector (MV)
- 1x Chemical Reactor (MV)
- 4x Double Titanium Plate
- 2x Fluid Regulator (EV)
- 4x Small PTFE Fluid Pipe
- 2x Quicklime Dust
- 1x Respiration I Enchanted Book
- 1x Holding I Enchanted Book
- 1x Normal Pressure Tank

In Advanced (Tier 2/5x5) Extended Crafting Table

![image](https://github.com/user-attachments/assets/3e06e398-1abc-4339-9a72-86788690cf31)

## Changes from Previous Recipes:
- Outputs 1 Book (or Equivalent), instead of 4

### Normal Mode:
- Aluminium Foil, Duct Tape, Cloth & Carbon Mesh have their amounts halved
- 1 Fluid Regulator instead of 4
- Gas Collector is MV instead of HV
- 1 Pressure Tank instead of 3

#### Old Recipe:
![image](https://github.com/user-attachments/assets/9ef60973-3766-4167-825e-0279c627b8ed)

### Expert Mode:
- Styrene Butadiene Rubber Rings instead of Rubber Rings
- Gas Collector and Chemical Reactor is MV instead of HV
- Respiration and Holding are Level I instead of Levels III and IV Respectively
- 4 Small PTFE Pipes instead of 2 Normal PTFE Pipes
- 2 Quicklime Dust instead of 1

#### Old Recipe:
![image](https://github.com/user-attachments/assets/7219b3e8-2eb4-4b34-b4be-f63e89d5b210)