### PR TITLE
Migrating to AR reworked

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -153,13 +153,13 @@
       "required": true
     },
     {
-      "projectID": 236541,
-      "fileID": 2949886,
+      "projectID": 1038780,
+      "fileID": 5732205,
       "required": true
     },
     {
-      "projectID": 236542,
-      "fileID": 3015079,
+      "projectID": 1024225,
+      "fileID": 5723687,
       "required": true
     },
     {

--- a/overrides/config/advRocketry/advancedRocketry.cfg
+++ b/overrides/config/advRocketry/advancedRocketry.cfg
@@ -1,57 +1,28 @@
 # Configuration file
 
-asteroid {
-    # Multiplier changing how long a mining mission takes
-    D:miningMissionTmeMultiplier=1.0
-
-    # List of oredictionary names of ores allowed to spawn in asteriods
-    S:standardOres <
-        oreIron
-        oreGold
-        oreCopper
-        oreTin
-        oreRedstone
-     >
-}
-
-
-black_hole_generator {
-    # List of blocks and the amount of ticks they can power the black hole generator format: 'modname:block:meta;number_of_ticks'
-    S:blackHoleTimings <
-        minecraft:stone;1
-        minecraft:dirt;1
-        minecraft:netherrack;1
-        minecraft:cobblestone;1
-     >
-
-    # List of blocks and the amount of ticks they can power the black hole generator format: 'modname:block:meta;number_of_ticks'
-    I:defaultBurnTime=500
-}
-
-
-##########################################################################################################
-# client
-#--------------------------------------------------------------------------------------------------------#
-# UI locations can by set by clicking and dragging the middle mouse button ingame
-##########################################################################################################
-
 client {
+    # If true, allows players to experience nausea on non-standard atmosphere types
+    B:EnableAtmosphericNausea=true
+
     # If true, AR will use a custom skybox on planets
     B:PlanetSkyOverride=true
 
     # If true, AR will use a custom skybox on space stations
     B:StationSkyOverride=true
+
+    # Advanced visual effects
+    B:advancedVFX=true
     I:atmBarModeX=-1
     I:atmBarModeY=1
     I:atmBarX=8
     I:atmBarY=27
+
+    # Should Electric Mushrooms be able to spawn lightning
+    B:electricPlantsSpawnLightning=true
     I:hydrogenBarModeX=0
     I:hydrogenBarModeY=1
     I:hydrogenBarX=-8
     I:hydrogenBarY=74
-
-    # If UI is not locked, the middle mouse can be used to drag certain AR UIs around the screen, positions are saved on hitting quit in the menu
-    B:lockUI=true
     B:overworldSkyOverride=true
     I:oxygenBarModeX=0
     I:oxygenBarModeY=1
@@ -64,32 +35,30 @@ client {
 }
 
 
-gasmining {
-    # Multiplier for the amount of time gas collection missions take
-    D:gasMissionMultiplier=1.0
+"energy production" {
+    # Multiplier for the amount of energy produced by the microwave reciever
+    D:MicrowaveRecieverMultiplier=1.0
 
-    # list of fluid names that can be harvested as Gas [default: ]
-    S:harvestableGasses <
+    # Multiplier for the amount of power per tick the black hole generator should produce
+    I:blackHoleGeneratorMultiplier=1
+
+    # List of blocks and the amount of ticks they can power the black hole generator format: 'modname:block:meta;number_of_ticks'
+    S:blackHoleTimings <
+        minecraft:stone;1
+        minecraft:dirt;1
+        minecraft:netherrack;1
+        minecraft:cobblestone;1
      >
-    S:spawnableGasses <
-        hydrogen;125;1600;1.0
-        helium;125;1600;0.9
-        helium3;175;1600;0.2
-        oxygen;0;124;1.0
-        nitrogen;0;124;1.0
-        ammonia;0;124;0.75
-        methane;0;124;0.25
-     >
+
+    # List of blocks and the amount of ticks they can power the black hole generator format: 'modname:block:meta;number_of_ticks'
+    I:defaultBurnTime=500
+
+    # Amount of power per tick the solar generator should produce
+    I:solarGeneratorMultiplier=1
 }
 
 
 general {
-    # If true, allows players being hurt due to lack of oxygen and allows effects from non-standard atmosphere types
-    B:EnableAtmosphericEffects=true
-
-    # If true, allows players to experience nausea on non-standard atmosphere types
-    B:EnableAtmosphericNausea=false
-
     # Enables the laser drill machine
     B:EnableLaserDrill=true
 
@@ -99,83 +68,29 @@ general {
     # Power multiplier for the laser drill machine
     D:LaserDrillPowerMultiplier=50.0
 
-    # Multiplier for the amount of energy produced by the microwave reciever
-    D:MicrowaveRecieverMultiplier=1.0
-
-    # How high the rocket has to go before it reaches orbit [range: 255 ~ 2147483647, default: 1000]
-    I:OrbitHeight=1000
-
-    # Power consumption multiplier for the oxygen vent
-    D:OxygenVentPowerMultiplier=1.0
-
-    # setting this to false will will prevent resetPlanetsFromXML from being set to false upon world reload.  Recommended for those who want to force ALL saves to ALWAYS use the planetDefs XML in the /config folder.  Essentially that 'Are you sure you're sure' option.  If resetPlanetsFromXML is false, this option does nothing. [default: true]
-    B:ResetOnlyOnce=false
-
-    # The largest size a space station can be.  Should also be a power of 2 (512, 1024, 2048, 4096, ...).  CAUTION: CHANGING THIS OPTION WILL DAMAGE EXISTING STATIONS!!!
-    I:SpaceStationBuildRadius=2048
-
     # how many millibuckets/t are required to keep the terraformer running
     I:TerraformerFluidConsumeRate=40
+
+    # Whether the Terraformer should consume fluids at all, independent of rate
     B:TerraformerRequiresFluids=true
-
-    # If true players will respawn near beds on planets IF the spawn location is in a breathable atmosphere
-    B:allowPlanetRespawn=true
-
-    # EXPERIMENTAL: If set to true allows contruction and usage of the terraformer.  This is known to cause strange world generation after successful terraform
-    B:allowTerraforming=false
 
     # If true dimensions not added by AR can be terraformed, including the overworld
     B:allowTerraformingNonARWorlds=false
 
-    # If true players will be able to completely disable gravity on spacestation.  It's possible to get stuck and require a teleport, you have been warned!
-    B:allowZeroGSpacestations=false
-
-    # How many blocks have the biome changed per tick.  Large numbers can slow the server down
-    I:biomeUpdateSpeed=1
-
-    # Multiplier for the amount of power per tick the black hole generator should produce
-    I:blackHoleGeneratorMultiplier=1
+    # Multiplier for the pressurized tank's (block) capacity
+    D:blockTankCapacity=1.0
 
     # Multiplier for the build speed of the Rocket Builder (0.5 is twice as fast 2 is half as fast
     D:buildSpeedMultiplier=1.0
 
-    # If true, breaking an extinguished torch will drop an extinguished torch instead of a vanilla torch
-    B:dropExtinguishedTorches=false
-
-    # Should Electric Mushrooms be able to spawn lightning
-    B:electricPlantsSpawnLightning=true
+    # Maximum gravity the crystalliser will function at. Use 0.0 to disable!
+    D:crystalliserMaximumGravity=0.0
 
     # If false the gravity controller cannot be built or used
     B:enableGravityMachine=true
 
-    # list entities which should not be affected by atmosphere properties [default: ]
-    S:entityAtmBypass <
-     >
-
-    # If true, rockets will be able to actually fly around space, EXPERIMENTAL
-    B:experimentalSpaceFlight=false
-
-    # If true players will respawn near beds on planets REGARDLESS of the spawn location being in a non-breathable atmosphere. Requires 'allowPlanetRespawn' being true.
-    B:forcePlanetRespawn=false
-
-    # If true planets with higher gravity require more fuel and lower gravity would require less
-    B:gravityAffectsFuels=true
-
     # Amount of force the jetpack provides with respect to gravity, 1 is the same acceleration as caused by Earth's gravity, 2 is 2x the acceleration caused by Earth's gravity, etc.  To make jetpack only work on low gravity planets, simply set it to a value less than 1
     D:jetPackForce=1.3
-
-    # List of oredictionary names of ores allowed to be mined by the laser drill if surface drilling is disabled.  Ores can be specified by just the oreName:<size> or by <modname>:<blockname>:<meta>:<size> where size is optional
-    S:laserDrillOres <
-        oreIron
-        oreGold
-        oreCopper
-        oreTin
-        oreRedstone
-        oreDiamond
-     >
-
-    # True if the ores in laserDrillOres should be a blacklist, false for whitelist
-    B:laserDrillOres_blacklist=false
 
     # If true the orbital laser will actually mine blocks on the planet below
     B:laserDrillPlanet=true
@@ -193,33 +108,52 @@ general {
         nuggetIridium:1
      >
 
+    # The power per tick required to process enriched lava [range: 0 ~ 999999, default: 10]
+    I:lavaCentrifugePower=10
+
+    # The time required to process 250mb of enriched lava [range: 0 ~ 999999, default: 50]
+    I:lavaCentrifugeTime=50
+
     # If true the boots only protect the player on planets with low gravity
     B:lowGravityBoots=false
 
     # If true the machines from AdvancedRocketry will produce things like plates/rods for other mods even if Advanced Rocketry itself does not use the material (This can increase load time)
     B:makeMaterialsForOtherMods=false
 
-    # Maximum unique biomes per planet, -1 to disable
-    I:maxBiomesPerPlanet=5
-
-    # Multiplier on how much O2 an oxygen vent consumes per tick
-    D:oxygenVentConsumptionMultiplier=1.0
-
-    # If true planets must be discovered in the warp controller before being visible
-    B:planetsMustBeDiscovered=false
-
-    # How many units of fuel should each Dilithium Crystal give to warp ships
-    I:pointsPerDilithium=500
-
     # setting this to true will force AR to read from the XML file in the config/advRocketry instead of the local data, intended for use pack developers to ensure updates are pushed through [default: false]
-    B:resetPlanetsFromXML=true
-
-    # Mod:Blockname  for example "minecraft:chest" [default: [minecraft:portal], [minecraft:bedrock], [minecraft:snow_layer], [minecraft:water], [minecraft:flowing_water], [minecraft:lava], [minecraft:flowing_lava]]
-    S:rocketBlockBlackList <
-     >
+    B:resetPlanetsFromXML=false
 
     # Should the cutting machine be able to cut vanilla wood into planks
     B:sawMillCutVanillaWood=false
+
+    # Laser drill will not mine these dimension [default: ]
+    S:spaceLaserDimIdBlackList <
+     >
+
+    # Multplier for atmosphere change speed
+    D:terraformMult=1.0
+}
+
+
+"oxygen system" {
+    # If true, allows players being hurt due to lack of oxygen and allows effects from non-standard atmosphere types
+    B:EnableAtmosphericEffects=true
+
+    # If true Galacticcraft's air will be disabled entirely requiring use of Advanced Rocketry's Oxygen system on GC planets
+    B:OverrideGCAir=true
+
+    # Power consumption multiplier for the oxygen vent
+    D:OxygenVentPowerMultiplier=1.0
+
+    # If true, breaking an extinguished torch will drop an extinguished torch instead of a vanilla torch
+    B:dropExtinguishedTorches=false
+
+    # list entities which should not be affected by atmosphere properties [default: ]
+    S:entityAtmBypass <
+     >
+
+    # Multiplier on how much O2 an oxygen vent consumes per tick
+    D:oxygenVentConsumptionMultiplier=1.0
 
     # If true the Oxygen scrubbers require a consumable carbon collection cartridge
     B:scrubberRequiresCartrige=true
@@ -232,24 +166,11 @@ general {
     S:sealableBlockWhiteList <
      >
 
-    # Amount of power per tick the solar generator should produce
-    I:solarGeneratorMultiplier=1
-
-    # Laser drill will not mine these dimension [default: ]
-    S:spaceLaserDimIdBlackList <
-     >
-
-    # Dimension ID to use for space stations
-    I:spaceStationId=-2
-
     # Maximum time in minutes that the spacesuit's internal buffer can store O2 for
     I:spaceSuitO2Buffer=30
 
-    # Max number of blocks allowed to be changed per tick
-    I:terraformBlockPerTick=1
-
-    # Multplier for atmosphere change speed
-    D:terraformMult=1.0
+    # Global multiplier for suit extra tank capacity
+    D:suitTankCapacity=1.0
 
     # Mod:Blockname  for example "minecraft:chest" [default: ]
     S:torchBlocks <
@@ -257,19 +178,195 @@ general {
 
     # Amount of damage taken every second in a vacuum
     I:vacuumDamage=1
+}
+
+
+performance {
+    # BitMask: 0: no threading, radius based; 1: threading, radius based (EXP); 2: no threading volume based; 3: threading volume based (EXP)
+    I:atmosphereCalculationMethod=3
+
+    # Radius of the O2 vent.  if atmosphereCalculationMethod is 2 or 3 then max volume is calculated from this radius.  WARNING: larger numbers can lead to lag
+    I:oxygenVentSize=32
+}
+
+
+planet {
+    # List of Biomes to be blacklisted from spawning as BiomeIds during terraforming [default: [minecraft:sky], [minecraft:hell], [minecraft:void]]
+    S:BlacklistedBiomes <
+        7
+        8
+        9
+        127
+        43
+     >
+
+    # Biomes that only spawn on worlds with pressures over 125, will override blacklist.  Defaults: StormLands, DeepSwamp [default: [advancedrocketry:deepswamp], [advancedrocketry:stormland]]
+    S:HighPressureBiomes <
+        48
+        46
+     >
+
+    # setting this to false will will prevent resetPlanetsFromXML from being set to false upon world reload.  Recommended for those who want to force ALL saves to ALWAYS use the planetDefs XML in the /config folder.  Essentially that 'Are you sure you're sure' option.  If resetPlanetsFromXML is false, this option does nothing. [default: true]
+    B:ResetOnlyOnce=false
+
+    # Some worlds have a chance of spawning single biomes contained in this list.  Defaults: deepSwamp, crystalChasms, alienForest, desert hills, mushroom island, extreme hills, ice plains [default: [advancedrocketry:volcanicbarren], [advancedrocketry:deepswamp], [advancedrocketry:crystalchasms], [advancedrocketry:alien_forest], [minecraft:desert_hills], [minecraft:mushroom_island], [minecraft:extreme_hills], [minecraft:ice_flats]]
+    S:SingleBiomes <
+        48
+        47
+        43
+        17
+        14
+        3
+        12
+     >
+
+    # If true players will respawn near beds on planets IF the spawn location is in a breathable atmosphere
+    B:allowPlanetRespawn=true
+
+    # Prevents any vanilla biomes from spawning on planets [default: false]
+    B:blackListVanillaBiomes=false
+
+    # If true players will respawn near beds on planets REGARDLESS of the spawn location being in a non-breathable atmosphere. Requires 'allowPlanetRespawn' being true.
+    B:forcePlanetRespawn=false
+
+    # Maximum unique biomes per planet
+    I:maxBiomesPerPlanet=5
+
+    # Dimensions including and after this number are allowed to be made into planets [range: -127 ~ 8000, default: 2]
+    I:minDimension=2
+
+    # Chance of planet discovery in the warp ship monitor is not all planets are initially discoved, chance is 1/n
+    I:planetDiscoveryChance=5
+
+    # If true planets must be discovered in the warp controller before being visible
+    B:planetsMustBeDiscovered=false
+
+    # Whether the planets should be reset from the config XML on this restart
+    B:resetPlanetsFromXML=true
+}
+
+
+"resource collection missions" {
+    # Multiplier for the amount of time gas collection missions take
+    D:gasMissionMultiplier=1.0
+
+    # list of fluid names that can be harvested as Gas from any gas giant [default: ]
+    S:harvestableGasses <
+     >
+
+    # Multiplier changing how long a mining mission takes
+    D:miningMissionTmeMultiplier=1.0
+
+    # list of fluid names that can be spawned as a gas giant. Format is fluid;minGravity;maxGravity;chance [default: [hydrogen;125;1600;1.0], [helium;125;1600;0.9], [helium3;175;1600;0.2], [oxygen;0;124;1.0], [nitrogen;0;124;1.0], [ammonia;0;124;0.75], [methane;0;124;0.25]]
+    S:spawnableGasses <
+        hydrogen;125;1600;1.0
+        helium;125;1600;0.9
+        helium3;175;1600;0.2
+        oxygen;0;124;1.0
+        nitrogen;0;124;1.0
+        ammonia;0;124;0.75
+        methane;0;124;0.25
+     >
+}
+
+
+rockets {
+    # Enables advanced weight system which computes rocket weight, including the handled inventories. Block weights are stores in weights.json
+    B:advancedWeightSystem=true
+
+    # The multiplier that asteroids should be considered as for TBI distance
+    D:asteroidTBIBurnMult=1.0
+
+    # Setting to false will disable the retrorockets that fire automatically on reentry on both player and automated rockets
+    B:autoRetroRockets=true
+
+    # Set to false if rockets should not be able to be fueled by and and will require a fueling station
+    B:canBeFueledByHand=false
+
+    # If true, rockets will be able to actually fly around space, EXPERIMENTAL
+    B:experimentalSpaceFlight=false
+
+    # Multiplier for per-tank capacity
+    D:fuelCapacityMultiplier=1.0
+
+    # If true planets with higher gravity require more fuel and lower gravity would require less
+    B:gravityAffectsFuels=true
+
+    # Every rocket usage every part has this probability to increase wear intensity
+    D:increaseWearIntensityProb=0.025
+
+    # If true rocket launches will kill plants, glass soil, turn rock into lava, and more
+    B:launchBlockDestruction=false
+
+    # The multiplier for the thrust of the nuclear core block. With default configuration, this value provides a (max) thrust of 1000 per core.
+    D:nuclearCoreThrustRatio=1.0
+
+    # How high the rocket has to go before it reaches orbit. This is used by itself when launching from a planet to LEO, which can be either a satellite, a space station, or another point on this planet's surface. It's used in conjunction with the TBI burn when launching to the moon or asteroids. Warp flights will need orbit height + 10x TBI to launch from planets [range: 255 ~ 2147483647, default: 1000]
+    I:orbitHeight=1000
+
+    # Enables rocket parts wear subsystem. Every rocket start it has probability to explode based on parts' wear intensities
+    B:partsWearSystem=true
+
+    # List of fluid names for fluids that can be used as rocket bipropellant fuels
+    S:rocketBipropellants <
+        hydrogen
+     >
+
+    # Mod:Blockname  for example "minecraft:chest" [default: [minecraft:portal], [minecraft:bedrock], [minecraft:snow_layer], [minecraft:water], [minecraft:flowing_water], [minecraft:lava], [minecraft:flowing_lava], [minecraft:fire], [advancedrocketry:rocketfire]]
+    S:rocketBlockBlackList <
+     >
+
+    # List of fluid names for fluids that can be used as rocket monopropellants
+    S:rocketFuels <
+        rocket_fuel
+     >
+
+    # List of fluid names for fluids that can be used as rocket nuclear working fluids
+    S:rocketNuclearWorkingFluids <
+        hydrogen
+     >
+
+    # List of fluid names for fluids that can be used as rocket bipropellant oxidizers
+    S:rocketOxidizers <
+        oxygen
+     >
+
+    # Set to false if rockets should not require fuel to fly
+    B:rocketsRequireFuel=true
+
+    # How high the rocket has to go before it clears a space station and can enter its own orbit - WARNING: This property is not synced with orbitHeight and so will be displayed incorrectly on monitors if not equal to it. Burn length here is used by itself when launching from a station to either another station or the same station, or to the planet it is orbiting. it is used in conjunction with the TBI burn when launching to a moon or asteroid [range: 255 ~ 2147483647, default: 1000]
+    I:stationClearance=1000
+
+    # Multiplier for per-engine thrust
+    D:thrustMultiplier=1.0
+
+    # How long the burn for trans-body injection is - this is performed soley after entering orbit and is in blocks - WARNING: This property is not taken into account by any machines when determining whether the rocket is fit to fly or not - Rockets that can reach LEO and so are flightworthy may not make TBI and will fall back to the parent planet. When enabled, the burn sequence is [Burn to LEO], [TBI Burn] when launching from a planet to moons or asteroids; and the sequence is [Station clearance burn], [TBI Burn] when launching from a station to a moon or asteroid. This distance varies by object distance [range: 0 ~ 2147483647, default: 0]
+    I:transBodyInjection=0
+
+    # The multiplier that warp rocket flights should be considered as for TBI distance
+    D:warpTBIBurnMult=10.0
+}
+
+
+"station configuration" {
+    # The largest size a space station can be.  Should also be a power of 2 (512, 1024, 2048, 4096, ...).  CAUTION: CHANGING THIS OPTION WILL DAMAGE EXISTING STATIONS!!!
+    I:SpaceStationBuildRadius=2048
+
+    # If true players will be able to completely disable gravity on spacestation.  It's possible to get stuck and require a teleport, you have been warned!
+    B:allowZeroGSpacestations=false
+
+    # How many units of fuel should each Dilithium Crystal give to warp ships
+    I:pointsPerDilithium=500
+
+    # Dimension ID to use for space stations
+    I:spaceStationId=-2
 
     # Multiplier for warp travel time
     D:warpTravelTime=1.0
 }
 
 
-"mod interaction" {
-    # If true Galacticcraft's air will be disabled entirely requiring use of Advanced Rocketry's Oxygen system on GC planets
-    B:OverrideGCAir=true
-}
-
-
-"ore generation" {
+"world and ore generation" {
     I:AluminumPerChunk=0
     I:AluminumPerClump=16
     I:CopperPerChunk=0
@@ -320,95 +417,19 @@ general {
 
     # variation in geode size
     I:geodeVariation=24
-}
 
-
-performance {
-    # Advanced visual effects
-    B:advancedVFX=true
-
-    # BitMask: 0: no threading, radius based; 1: threading, radius based (EXP); 2: no threading volume based; 3: threading volume based (EXP)
-    I:atmosphereCalculationMethod=3
-
-    # Radius of the O2 vent.  if atmosphereCalculationMethod is 2 or 3 then max volume is calculated from this radius.  WARNING: larger numbers can lead to lag
-    I:oxygenVentSize=32
-}
-
-
-planet {
-    # List of Biomes to be blacklisted from spawning as BiomeIds, default is: river, sky, hell, void, alienForest [default: [minecraft:river], [minecraft:sky], [minecraft:hell], [minecraft:void], [advancedrocketry:alien forest]]
-    S:BlacklistedBiomes <
-        7
-        8
-        9
-        127
-        43
+    # List of oredictionary names of ores allowed to be mined by the laser drill if surface drilling is disabled.  Ores can be specified by just the oreName:<size> or by <modname>:<blockname>:<meta>:<size> where size is optional
+    S:laserDrillOres <
+        oreIron
+        oreGold
+        oreCopper
+        oreTin
+        oreRedstone
+        oreDiamond
      >
 
-    # Biomes that only spawn on worlds with pressures over 125, will override blacklist.  Defaults: StormLands, DeepSwamp [default: [advancedrocketry:deepswamp], [advancedrocketry:stormland]]
-    S:HighPressureBiomes <
-        48
-        46
-     >
-
-    # Some worlds have a chance of spawning single biomes contained in this list.  Defaults: deepSwamp, crystalChasms, alienForest, desert hills, mushroom island, extreme hills, ice plains [default: [advancedrocketry:volcanicbarren], [advancedrocketry:deepswamp], [advancedrocketry:crystalchasms], [advancedrocketry:alien forest], [minecraft:desert_hills], [minecraft:mushroom_island], [minecraft:extreme_hills], [minecraft:ice_flats]]
-    S:SingleBiomes <
-        48
-        47
-        43
-        17
-        14
-        3
-        12
-     >
-
-    # Prevents any vanilla biomes from spawning on planets [default: false]
-    B:blackListVanillaBiomes=false
-
-    # Dimensions including and after this number are allowed to be made into planets [range: -127 ~ 8000, default: 2]
-    I:minDimension=2
-
-    # Chance of planet discovery in the warp ship monitor is not all planets are initially discoved, chance is 1/n
-    I:planetDiscoveryChance=5
-}
-
-
-rockets {
-    D:asteroidTBIBurnMult=1.0
-
-    # Setting to false will disable the retrorockets that fire automatically on reentry on both player and automated rockets
-    B:autoRetroRockets=true
-    B:canBeFueledByHand=false
-
-    # Multiplier for per-tank capacity
-    D:fuelCapacityMultiplier=1.0
-    I:orbitHeight=1000
-    S:rocketBipropellants <
-        hydrogen
-     >
-
-    # List of fluid names for fluids that can be used as rocket fuel
-    S:rocketFuels <
-        rocket_fuel
-     >
-    S:rocketOxidizers <
-        oxygen
-     >
-
-    # Set to false if rockets should not require fuel to fly
-    B:rocketsRequireFuel=true
-    I:stationClearance=1000
-
-    # Multiplier for per-engine thrust
-    D:thrustMultiplier=1.0
-    I:transBodyInjection=0
-    D:warpTBIBurnMult=10.0
-}
-
-
-sealableblockwhitelist {
-    S:general <
-     >
+    # True if the ores in laserDrillOres should be a blacklist, false for whitelist. if set to false in combination with empty ore list it will crash the game
+    B:laserDrillOres_blacklist=false
 }
 
 

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -8,12 +8,6 @@ import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.*
 // AR
 mods.jei.ingredient.removeAndHide(item('advancedrocketry:crystal:*')) // Random Crystal Blocks
 
-removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketrocketfuel'))
-removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketnitrogen'))
-removeAndHideItemIgnoreNBT(item('advancedrocketry:buckethydrogen'))
-removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketoxygen'))
-removeAndHideItemIgnoreNBT(item('advancedrocketry:bucketenrichedlava'))
-
 // Armor Plus
 mods.jei.ingredient.removeAndHide(item('armorplus:block_melting_obsidian')) // Null Texture Item
 

--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -924,7 +924,6 @@ mods.jei.JEI.removeAndHide(<advancedrocketry:basalt>);       // Basalt
 mods.jei.JEI.removeAndHide(<advancedrocketry:landingfloat>); // Landing Float
 mods.jei.JEI.removeAndHide(<advancedrocketry:airlock_door>); // Airlock Door (Technical Block)
 mods.jei.JEI.removeAndHide(<advancedrocketry:lightsource>);  // Light source (Technical Block)
-mods.jei.JEI.removeAndHide(<advancedrocketry:astrobed>);     // Astrobed     (Technical Block)
 
 //AR Rocket fuel, unusable
 mods.jei.JEI.removeAndHide(<forge:bucketfilled>.withTag({FluidName: "rocketfuel", Amount: 1000}));

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1559,7 +1559,6 @@ mods.jei.JEI.removeAndHide(<advancedrocketry:microwavereciever>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:drill>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:solarpanel>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:biomescanner>);
-mods.jei.JEI.removeAndHide(<advancedrocketry:terraformer>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:deployablerocketbuilder>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:liquidtank>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:intake>);


### PR DESCRIPTION
This PR migrates the old AR and LibVulpes to their forks (https://www.curseforge.com/minecraft/mc-mods/advanced-rocketry-2, https://www.curseforge.com/minecraft/mc-mods/library-for-ar-reworked). Config updated and double checked. Scripts updated but only to solve errors ingame, there might be some lines that are no longer needed in the forked AR but not removed.


- No error reported, doesn't seem to cause anything to malfunction, but I personally haven't had a chance to further explore the mod so there's still a chance it leads to, although not likely, some problems.
- Nomi Labs needs to be updated to remove codes related to solving the old bugs from the old AR that has been fixed in the forked version. Now with Nomi Labs 0.9.4 the game crashes on startup: https://mclo.gs/YKeFhvb.