### PR TITLE
Fix Server Side GrS Error

### DIFF
--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -51,6 +51,8 @@ advanced {
         gregtech/api/recipes/recipeproperties/ScanProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TotalComputationProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
+        gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
      >
 
     # Whether to disable the Narrator.


### PR DESCRIPTION
This PR simply fixes a server side GrS error in `nbtClearing.groovy`, caused by incorrectly annotated methods in `MetaTileEntityQuantumChest` and `MetaTileEntityQuantumTank`.