### PR TITLE
Fix Issues with Loading Labs Config on Cleanroom Servers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -715,7 +715,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5793270,
+      "fileID": 5798781,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs to 0.9.5, which fixes issues with loading Nomi-Labs' config on Cleanroom Servers.