### PR TITLE
Fix Empty Locked Drawers Resetting on World Load

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -715,7 +715,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5798781,
+      "fileID": 5807317,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs to v0.9.6, which fixes an issue with empty locked drawers resetting on world load.

Fixes #1059 