### PR TITLE
Add Tooltips Saying P2P Type

### DIFF
--- a/overrides/groovy/classes/postInit/common.groovy
+++ b/overrides/groovy/classes/postInit/common.groovy
@@ -1,11 +1,12 @@
 package classes.postInit
 
 import net.minecraft.item.ItemStack
+import org.apache.commons.lang3.tuple.Pair
 
 class Common {
 	/* Cached Values */
 	private static ItemStack meP2p = null
-	private static List<ItemStack> p2pVariants = null
+	private static List<Pair<String, ItemStack>> p2pVariants = null
 	private static List<ItemStack> eioGlasses = null
 
 	static ItemStack getMeP2p() {
@@ -15,17 +16,17 @@ class Common {
 		return meP2p
 	}
 	// All P2P Variants, Excluding ME P2P
-	static List<ItemStack> getP2pVariants() {
+	static List<Pair<String, ItemStack>> getP2pVariants() {
 		if (p2pVariants != null) return p2pVariants
 
 		p2pVariants = [
-			item('appliedenergistics2:part', 461), // Redstone
-			item('appliedenergistics2:part', 462), // Item
-			item('appliedenergistics2:part', 463), // Fluid
-			item('appliedenergistics2:part', 467), // Light
-			item('appliedenergistics2:part', 469), // RF
-			item('appliedenergistics2:part', 470), // EU
-			item('nae2:part', 1), // Interface
+			Pair.of('Redstone', item('appliedenergistics2:part', 461)),
+			Pair.of('Item', item('appliedenergistics2:part', 462)),
+			Pair.of('Fluid', item('appliedenergistics2:part', 463)),
+			Pair.of('Light', item('appliedenergistics2:part', 467)),
+			Pair.of('RF', item('appliedenergistics2:part', 469)),
+			Pair.of('EU', item('appliedenergistics2:part', 470)),
+			Pair.of('Interface', item('nae2:part', 1)),
 		]
 		return p2pVariants
 	}

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -149,12 +149,16 @@ addTooltip(item('appliedenergistics2:material', 1), translatable('nomiceu.toolti
 addTooltip(Common.meP2p, [
 	translatable('nomiceu.tooltip.ae2.p2p.me'),
 	translatableEmpty(),
+	translatable('nomiceu.tooltip.ae2.p2p.type', 'ME'),
 	translatable("nomiceu.tooltip.ae2.p2p.desc"),
 ])
 
-// Global P2P
-for (ItemStack item : Common.p2pVariants) {
-	addTooltip(item, translatable("nomiceu.tooltip.ae2.p2p.desc"))
+// Other P2P
+for (var item : Common.p2pVariants) {
+	addTooltip(item.value, [
+		translatable('nomiceu.tooltip.ae2.p2p.type', item.key),
+		translatable("nomiceu.tooltip.ae2.p2p.desc"),
+	])
 }
 
 

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/ae2/p2p.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/ae2/p2p.groovy
@@ -6,7 +6,7 @@ import static gregtech.api.GTValues.*
 // Create an OreDict for P2Ps
 OreDictIngredient p2pOre = ore('ae2P2ps')
 p2pOre.add(Common.meP2p)
-p2pOre.add(Common.p2pVariants)
+p2pOre.add(Common.p2pVariants.collect { it -> it.value })
 
 // Crafting Recipe: Shapeless, Any P2P (Ore Dict) -> ME P2P
 crafting.addShapeless(Common.meP2p, [p2pOre])
@@ -16,7 +16,7 @@ for (int i : 0..Common.p2pVariants.size() - 1) {
 	mods.gregtech.assembler.recipeBuilder()
 		.inputs(p2pOre)
 		.circuitMeta(i + 1)
-		.outputs(Common.p2pVariants[i])
+		.outputs(Common.p2pVariants[i].value)
 		.duration(10).EUt(VA[LV])
 		.buildAndRegister()
 }

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -51,6 +51,7 @@ nomiceu.tooltip.ae2.pure_fluix=§aMade in a Crystal Growth Chamber from a Fluix 
 nomiceu.tooltip.ae2.charged_certus=§bObtained by charging with RF power in the AE2 Charger, or the Energetic Infuser.§r
 nomiceu.tooltip.ae2.p2p.me=§bThe basis for all other P2P Tunnels.§r
 nomiceu.tooltip.ae2.p2p.desc=§aShift and scroll whilst holding to cycle through P2P types!§r
+nomiceu.tooltip.ae2.p2p.type=Type: %s
 nomiceu.tooltip.ae2.channels_not_enabled=Channels not enabled!
 nomiceu.tooltip.ae2.controller=§bThe ME Controller reduces your AE2 system's power consumption!§r
 nomiceu.tooltip.ae2.dense=§bFor decoration!§r


### PR DESCRIPTION
This PR adds tooltips on P2Ps saying the P2P type.

Useful for renamed P2Ps.

Fixes #1063