### PR TITLE
Add the FindMyItemsAndFluids Mod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -619,6 +619,11 @@
       "required": true
     },
     {
+      "projectID": 610085,
+      "fileID": 3748963,
+      "required": true
+    },
+    {
       "projectID": 616190,
       "fileID": 4630499,
       "required": true

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/keybindOverrides.groovy
@@ -34,6 +34,7 @@ addOverride('enderio.keybind.inventory', KeyModifier.SHIFT, Keyboard.KEY_C)
 addOverride('key.draconicevolution.toolConfig', KeyModifier.SHIFT, Keyboard.KEY_C)
 
 // This one is special: It fixes the bug where pressing T in JEI/AE2 would sometimes force you out of the GUI
+// Its also replaced by a different mod, FindMyItemsAndFluids.
 addOverride('key.xu2.searchforitems', Keyboard.KEY_NONE)
 
 addOverride('key.ftbutilities.nbt', Keyboard.KEY_NONE)


### PR DESCRIPTION
This PR adds a mod: the FindMyItemsAndFluids Mod.

This allows for players to search nearby inventories for items, allowing for a much better experience before AE2.

This feature existed in the past, added by XU2, but that feature caused issues when searching on AE2 terminals. This mod does not have those issues, and additionally, allows searching for fluids, whether in buckets or in other fluid display GUIs.

Quests will be added in a seperate PR.