### PR TITLE
Fix Wrong Default Visibility in Quest Transform Task

### DIFF
--- a/tools/tasks/shared/quest.ts
+++ b/tools/tasks/shared/quest.ts
@@ -78,7 +78,7 @@ const uselessProps: Record<string, string | number> = {
 	"tasklogic:8": "AND",
 	"questlogic:8": "AND",
 	"entryLogic:8": "AND",
-	"visibility:8": "NORMAL",
+	"visibility:8": "ALWAYS",
 	"partysinglereward:1": 0,
 	"lockedprogress:1": 0,
 	"OreDict:8": "",


### PR DESCRIPTION
This PR updates the questbook transform tasks to changes made in #960, which changed the default quest visibility to ALWAYS.