### PR TITLE
More Fixes for Randomly Unlocking Drawers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -720,7 +720,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5810986,
+      "fileID": 5813879,
       "required": true
     },
     {


### PR DESCRIPTION
This PR fixes locked drawers with no items resetting in two cases:
- Being broken and replaced
- Using other keys (quantify, etc.)

Fixes #1070 