### PR TITLE
Fix Changelog Downloading from Branch

### DIFF
--- a/tools/tasks/shared/index.ts
+++ b/tools/tasks/shared/index.ts
@@ -150,7 +150,7 @@ async function fetchOrMakeChangelog() {
 				filename: "CHANGELOG.md",
 			}),
 			mustache.render(url, {
-				branch: process.env.CHANGELOG_BRNACH,
+				branch: process.env.CHANGELOG_BRANCH,
 				filename: "CHANGELOG_CF.md",
 			}),
 		);


### PR DESCRIPTION
This PR fixes changelog downloading from branch throwing an error.

Why do I write these descriptions anymore?

If your wondering what the issue was? I spelt `BRANCH` as `BRNACH`. According to Git Blame, this has gone unnoticed for 5 Months.