### PR TITLE
Update LoliASM Config

### DIFF
--- a/overrides/config/loliasm.cfg
+++ b/overrides/config/loliasm.cfg
@@ -70,12 +70,18 @@ canonicalization {
 
 
 capability {
+    # Delays ItemStack's capabilities from being initialized until they needed to be - <default: true>
+    B:delayItemStackCapabilityInit=true
+
     # Fixes Astral Sorcery applying AmuletHolderCapability to large amount of ItemStacks when it isn't needed. This option will be ignored when Astral Sorcery isn't installed - <default: true>
     B:fixAmuletHolderCapability=true
 }
 
 
 datastructures {
+    # Improve hashing performances of various objects - <default: true>
+    B:efficientHashing=true
+
     # Clears and trims ModelManager data structures after models are loaded and baked - <default: true>
     B:moreModelManagerCleanup=true
 
@@ -88,14 +94,26 @@ datastructures {
     # Optimizes registries - <default: true>
     B:optimizeRegistries=true
 
+    # If JEI/HEI is installed, replace vanilla search trees with JEI's, decreases memory usage, loading time and adds more features to normal creative menu searching - <default: true>
+    B:replaceSearchTreeWithJEISearching=true
+
     # EXPERIMENTAL: Strips ItemStack of some of its fields as it stores some near-useless references - <default: true>
     B:stripNearUselessItemStackFields=true
+}
+
+
+events {
+    # [EXPERIMENTAL]: Stops mass object creation when Forge is firing events, this can decrease Garbage Collection pressure - <default: false>
+    B:makeEventsSingletons=false
 }
 
 
 forgefixes {
     # Fixes Forge's EntityEntry calling a slow Constructor::newInstance call every time an entity spawns, it is replaced with a fast Function::get generated from LambdaMetafactory#metafactory - <default: true>
     B:fasterEntitySpawnPreparation=true
+
+    # Works around a crash when too many dimensions are registered, caused by JVM optimization issues. - <default: true>
+    B:fixDimensionTypesInliningCrash=true
 
     # Fixes Forge's mistake of annotating FillBucketEvent#getFilledBucket as @Nonnull when the contract isn't fulfilled nor checked. First discovered here: https://github.com/Divine-Journey-2/main/issues/295 - <default: true>
     B:fixFillBucketEventNullPointerException=true
@@ -147,12 +165,60 @@ launchwrapper {
 }
 
 
+logging {
+    # Allow the game to keep running after crashes as well as adding more information and deobfuscating the crash reports, inspired by VanillaFix - <default: true>
+    B:crashReportImprovements=true
+
+    # When crashReportImprovements is true, disallow toasts from popping up and carry on playing while keeping crashes silent - <default: true>
+    B:hideToastsAndContinuePlaying=true
+
+    # When crashReportImprovements is true, allow the player to return to the main menu when a crash occurs, inspired by VanillaFix - <default: true>
+    B:returnToMainMenuAfterCrash=true
+
+    # Rewrite logging output with deobfuscated names when applicable, inspired by VanillaFix - <default: true>
+    B:rewriteLoggingWithDeobfuscatedNames=true
+}
+
+
+mcfixes {
+    # Fixes MC-129057: https://bugs.mojang.com/browse/MC-129057 - <default: true>
+    B:fixMC129057=true
+
+    # Fixes MC-129556: https://bugs.mojang.com/browse/MC-129556 - <default: true>
+    B:fixMC129556=true
+
+    # Fixes MC-186052: https://bugs.mojang.com/browse/MC-186052 - <default: true>
+    B:fixMC186052=true
+
+    # Fixes MC-30845: https://bugs.mojang.com/browse/MC-30845 - <default: true>
+    B:fixMC30845=true
+
+    # Fixes MC-31681: https://bugs.mojang.com/browse/MC-31681 - <default: true>
+    B:fixMC31681=true
+
+    # Fixes MC-88176: https://bugs.mojang.com/browse/MC-88176 - <default: true>
+    B:fixMC88176=true
+
+    # Limits skin downloading threads to a maximum of half of available CPU cores - <default: true>
+    B:limitSkinDownloadingThreads=true
+
+    # Resolves MC-2071: https://bugs.mojang.com/browse/MC-2071 - <default: true>
+    B:resolveMC2071=true
+}
+
+
 misc {
+    # Process screenshots and print to chat asynchronously - <default: true>
+    B:asyncScreenshot=true
+
     # [W.I.P] - EXPERIMENTAL: Yet another attempt at caching classes between loads - <default: false>
     B:classCaching=false
 
     # Copy image after screenshotting to clipboard - <default: false>
     B:copyScreenshotToClipboard=false
+
+    # Use updated CA Certs that was included in 8u311. This most notably fixes 8u51 certs issues - <default: true>
+    B:outdatedCaCertsFix=true
 
     # Optimizes FluidRegistry::enableUniversalBucket check - <default: true>
     B:quickerEnableUniversalBucketCheck=true
@@ -160,8 +226,17 @@ misc {
     # For some reason Mojang decided to cache int buffers and arrays after a screenshot is taken, this makes sure they're never cached - <default: true>
     B:releaseScreenshotCache=true
 
+    # Removes forced garbage collection calls, inspired by VanillaFix, can make world loading faster - <default: true>
+    B:removeExcessiveGCCalls=true
+
+    # Allows changing of dimensions to be smooth and nearly instantaneous, inspired by VanillaFix - <default: true>
+    B:smoothDimensionChange=true
+
     # Strips the boring instanced Random object from SoundEventAccessors and uses ThreadLocalRandom instead - <default: true>
     B:stripInstancedRandomFromSoundEventAccessor=true
+
+    # Adjust thread priorities to improve performance on systems with few cores - <default: true>
+    B:threadPriorityFix=true
 }
 
 
@@ -172,10 +247,16 @@ modfixes {
     # EXPERIMENTAL: When ChickenASM (Library of CodeChickenLib and co.) is installed, ClassHierarchyManager can cache a lot of Strings and seem to be unused in any transformation purposes. This clears ClassHierarchyManager of those redundant strings. This option will be ignored when ChickenASM isn't installed - <default: true>
     B:cleanupChickenASMClassHierarchyManager=true
 
+    # When Extra Utilities 2 is installed, disable the crafter's rendering of the item being crafted, this can reduce lag, ignores fixXU2CrafterCrash config option - <default: false>
+    B:disableXU2CrafterRendering=false
+
     # When Immersive Engineering is installed, sometimes it or it's addons can induce an ArrayIndexOutOfBoundsException in BlockIEBase#getPushReaction. This option will be ignored when IE isn't installed - <default: true>
     B:fixBlockIEBaseArrayIndexOutOfBoundsException=true
 
-    # When Extra Utilities 2 is installed, fix poor semantics in mechanical crafter's rendering that leads to crashes - <default: true>
+    # When TerraFirmaCraft is installed, fix the falling block's false starting position  - <default: true>
+    B:fixTFCFallingBlockFalseStartingTEPos=true
+
+    # When Extra Utilities 2 is installed, fix and optimize mechanical crafter's rendering - <default: true>
     B:fixXU2CrafterCrash=true
 
     # When Just Enough Items is installed, it deduplicates strings in the generated generalized suffix trees' edge labels. This option will be ignored when Just Enough Items isn't installed - <default: true>
@@ -226,6 +307,12 @@ spark {
     # When Spark is installed, profile the loading of the game in its entirety - <default: false>
     B:sparkProfileEntireGameLoad=false
 
+    # When Spark is installed, profile the loading of the world in its entirety - <default: false>
+    B:sparkProfileEntireWorldLoad=false
+
+    # When Spark is installed, profile the loading of FMLModIdMappingEvent stage, this is the last event fired before the game is finalized - <default: false>
+    B:sparkProfileFinalizingStage=false
+
     # When Spark is installed, profile the loading of FMLInitializationEvent stage - <default: false>
     B:sparkProfileInitializationStage=false
 
@@ -238,12 +325,27 @@ spark {
     # When Spark is installed, profile the loading of FMLPreInitializationEvent stage - <default: false>
     B:sparkProfilePreInitializationStage=false
 
+    # When Spark is installed, profile the loading of FMLServerAboutToStartEvent stage - <default: false>
+    B:sparkProfileWorldAboutToStartStage=false
+
+    # When Spark is installed, profile the loading of FMLServerStartedEvent stage - <default: false>
+    B:sparkProfileWorldStartedStage=false
+
+    # When Spark is installed, profile the loading of FMLServerStartingEvent stage - <default: false>
+    B:sparkProfileWorldStartingStage=false
+
     # When Spark is installed, summarize the heap space (/spark heapsummary) when the game finishes loading - <default: false>
     B:sparkSummarizeHeapSpaceAfterGameLoads=false
+
+    # When Spark is installed, summarize the heap space (/spark heapsummary) when the world finishes loading - <default: false>
+    B:sparkSummarizeHeapSpaceAfterWorldLoads=false
 }
 
 
 textures {
+    # Calculate and send animated textures only when needed to the GPU, better than VanillaFix's textureFixes config - <default: true>
+    B:onDemandAnimatedTextures=true
+
     # Releases TextureAtlasSprite's framesTextureData. Won't touch custom TextureAtlasSprite implementations - <default: true>
     B:releaseSpriteFramesCache=true
 }


### PR DESCRIPTION
This PR simply updates the LoliASM config to the state it becomes after running the game once.

This allows for easier customisations, such as the disabling of `threadPriorityFix` (for SpongeForge) and `onDemandAnimatedTextures`.

No behaviour has changed.