### PR TITLE
Remove Glowstone Electrolyzer Recipe

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/materialChanges.groovy
@@ -15,10 +15,17 @@ material('rhodium_plated_palladium')
 	.changeChemicalFormula()
 	.change()
 
+// Remove Glowstone Decomp (No Glowstone -> Phosphorous)
+material('glowstone')
+	.changeComposition()
+	.removeComponents()
+	.changeDecompositionRecipes()
+	.change()
+
+// Change Glowstone Chem Formula
 material('glowstone')
 	.changeComposition()
 	.setComponents([metaitem('dustGold'), metaitem('dustTricalciumPhosphate')])
-	.changeDecompositionRecipes()
 	.changeChemicalFormula()
 	.change()
 


### PR DESCRIPTION
This decomposition was accidentally added in 1.7-alpha-3, and then changed to its current recipe, but not removed, in 1.7-beta-6.

This PR fixes phosphorous balancing, removing a source of phosphorous that is too plentiful.