### PR TITLE
Fix Uncompletable Quests

### DIFF
--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -41143,7 +41143,7 @@
     },
     "647:10": {
       "preRequisites:11": [
-        169
+        889
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -56238,12 +56238,10 @@
     "888:10": {
       "preRequisiteTypes:7": [
         0,
-        0,
         1
       ],
       "preRequisites:11": [
-        161,
-        166,
+        184,
         826
       ],
       "properties:10": {

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -41143,7 +41143,7 @@
     },
     "647:10": {
       "preRequisites:11": [
-        169
+        889
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -56238,12 +56238,10 @@
     "888:10": {
       "preRequisiteTypes:7": [
         0,
-        0,
         1
       ],
       "preRequisites:11": [
-        161,
-        166,
+        184,
         826
       ],
       "properties:10": {

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -205,6 +205,10 @@
       "expert": 167
     },
     {
+      "normal": 169,
+      "expert": 169
+    },
+    {
       "normal": 171,
       "expert": 171
     },
@@ -231,6 +235,10 @@
     {
       "normal": 177,
       "expert": 177
+    },
+    {
+      "normal": 184,
+      "expert": 184
     },
     {
       "normal": 190,
@@ -465,6 +473,10 @@
       "expert": 606
     },
     {
+      "normal": 647,
+      "expert": 647
+    },
+    {
       "normal": 672,
       "expert": 672
     },
@@ -571,6 +583,14 @@
     {
       "normal": 880,
       "expert": 880
+    },
+    {
+      "normal": 888,
+      "expert": 888
+    },
+    {
+      "normal": 889,
+      "expert": 889
     },
     {
       "normal": 893,


### PR DESCRIPTION
This PR fixed breaking changes within the questbook, including:
- Palladium quest now requires platline quests so that it is copmletable
- Gasoline quest now requires Navigate Petrochem as the previous prerequisites prerequisites were deleted
