### PR TITLE
Remove Unused Import

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/thermal.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/thermal.groovy
@@ -1,7 +1,6 @@
 import com.nomiceu.nomilabs.groovy.SimpleIIngredient
 import com.nomiceu.nomilabs.util.ItemMeta
 import net.minecraft.item.ItemStack
-import net.minecraft.item.crafting.Ingredient
 
 /* Fix Tanks in JEI */
 // Remove All, then add them back


### PR DESCRIPTION
This PR makes a tiny change, simply removing an unused import from `thermal.groovy`.