### PR TITLE
Create Crafting Recipes for Early GT Cells

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
@@ -212,6 +212,41 @@ mods.gregtech.assembler.recipeBuilder()
 // Coke -> 16 Tiny Coke
 crafting.addShapeless(item('nomilabs:tiny_coke') * 16, [ore('fuelCoke')])
 
+/* Early Cell Recipes */
+// Basic Cell: Crafting
+crafting.shapedBuilder()
+	.output(metaitem('fluid_cell'))
+	.matrix('PHP', ' R ')
+	.key('P', ore('plateTin'))
+	.key('H', ore('toolHammer'))
+	.key('R', ore('ringIron'))
+	.register()
+
+// Bronze Cell: Assembler
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(ore('plateDoubleBronze') * 2, ore('ringTin') * 2)
+	.outputs(metaitem('nomilabs:bronze_cell'))
+	.duration(200).EUt(VA[LV])
+	.buildAndRegister()
+
+// Bronze Cell: Crafting
+crafting.shapedBuilder()
+	.output(metaitem('nomilabs:bronze_cell'))
+	.matrix('PHP', 'RRR')
+	.key('P', ore('plateDoubleBronze'))
+	.key('H', ore('toolHammer'))
+	.key('R', ore('ringTin'))
+	.register()
+
+// Steel Cell: Crafting
+crafting.shapedBuilder()
+	.output(metaitem('large_fluid_cell.steel'))
+	.matrix('PHP', 'RRR')
+	.key('P', ore('plateDoubleSteel'))
+	.key('H', ore('toolHammer'))
+	.key('R', ore('ringBronze'))
+	.register()
+
 // Lubricant Alternatives (Per Oil)
 ChangeRecipeBuilderCollection<SimpleRecipeBuilder> lubeRecipes = mods.gregtech.brewery.changeByOutput(
 	RecipePredicates.hasExactlyFluidInput(fluid('oil') * 1000),

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -30,6 +30,9 @@ for (def meta : 1..15) {
             translatable('nomiceu.tooltip.nc.nbt_clearing.cooler.warning'))
 }
 
+// Bronze Cell
+nbtClearingRecipe(metaitem('nomilabs:bronze_cell'))
+
 /* Drawers */
 // Add empty can clear tooltip, as we want to add multiple lines
 var empty = translatableEmpty()


### PR DESCRIPTION
This PR adds crafting recipes for early (tin, bronze and steel) GT cells.

Compared to their corresponding assembler recipes, these recipes cost 1 extra ring, and require a hammer.

This PR also adds crafting, assembler and nbt clearing recipes for the new Bronze Cell. The recipes are very similar to the steel cell, but with bronze double plates instead of steel double plates, and with tin rings instead of bronze rings.