### PR TITLE
Small Earlygame Tweaks

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
@@ -9,25 +9,6 @@ import net.minecraftforge.fluids.FluidStack
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
 
-// Allow treated wood sticks in (most) stick recipes
-ore('stickWood').add(metaitem('stickTreatedWood'))
-
-// Make Wood Frame Box only accept non-treated wood sticks
-// So we don't conflict with Treated Wood Frame Box recipe
-crafting.shapedBuilder()
-	.output(metaitem('frameWood') * 2)
-	.matrix('SSS', 'STS', 'SSS')
-	.key('S', item('minecraft:stick'))
-	.key('T', ore('toolSaw'))
-	.replace().register()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('minecraft:stick') * 4)
-	.circuitMeta(4)
-	.outputs(metaitem('frameWood'))
-	.duration(64).EUt(VA[ULV])
-	.replace().buildAndRegister()
-
 if (LabsModeHelper.expert) {
 	// Log -> Stick Shortcut (Expert Mode)
 	crafting.shapedBuilder()

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
@@ -9,6 +9,58 @@ import net.minecraftforge.fluids.FluidStack
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
 
+// Allow treated wood sticks in (most) stick recipes
+ore('stickWood').add(metaitem('stickTreatedWood'))
+
+// Make Wood Frame Box only accept non-treated wood sticks
+// So we don't conflict with Treated Wood Frame Box recipe
+crafting.shapedBuilder()
+	.output(metaitem('frameWood') * 2)
+	.matrix('SSS', 'STS', 'SSS')
+	.key('S', item('minecraft:stick'))
+	.key('T', ore('toolSaw'))
+	.replace().register()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('minecraft:stick') * 4)
+	.circuitMeta(4)
+	.outputs(metaitem('frameWood'))
+	.duration(64).EUt(VA[ULV])
+	.replace().buildAndRegister()
+
+if (LabsModeHelper.expert) {
+	// Log -> Stick Shortcut (Expert Mode)
+	crafting.shapedBuilder()
+		.output(item('minecraft:stick') * 4)
+		.matrix('B', 'B')
+		.key('B', ore('logWood'))
+		.register()
+
+	// Remove endercore paper recipe
+	crafting.remove('endercore:shapeless_paper')
+
+	// Remove aa paper recipe (with rice)
+	crafting.remove('actuallyadditions:recipes23')
+
+	// Allow rice -> paper through chad
+	crafting.shapedBuilder()
+		.output(metaitem('dustPaper') * 2)
+		.matrix('RRR', ' M ')
+		.key('R', item('actuallyadditions:item_food', 16))
+		.key('M', ore('toolMortar'))
+		.register()
+} else {
+	// Remove mc paper recipe, is useless with endercore's shapeless one
+	crafting.remove('minecraft:paper')
+}
+
+// Wood Pulp
+// Output 4 for Normal, 2 for Expert
+crafting.addShapeless(metaitem('dustWood') * (LabsModeHelper.expert ? 2 : 4), [ore('logWood'), ore('toolMortar')])
+
+// Remove Thermal Foundation's clay recipe, slag is unobtainable
+crafting.remove('thermalfoundation:clay_ball')
+
 // Furnaces
 // Iron Furnace
 mods.gregtech.assembler.recipeBuilder()

--- a/overrides/scripts/Alchemy.zs
+++ b/overrides/scripts/Alchemy.zs
@@ -7,15 +7,15 @@ import scripts.common.makeShaped as makeShaped;
 
 //Wooden Gear
 recipes.remove(<enderio:item_material:9>);
-recipes.addShaped(<enderio:item_material:9>, [[null,<minecraft:stick>,null],
-	[<minecraft:stick>,null,<minecraft:stick>],
-	[null,<minecraft:stick>,null]]);
+recipes.addShaped(<enderio:item_material:9>, [[null,<ore:stickWood>,null],
+	[<ore:stickWood>,null,<ore:stickWood>],
+	[null,<ore:stickWood>,null]]);
 
 //Wooden Shears
 recipes.remove(<thermalfoundation:tool.shears_wood>);
-recipes.addShaped(<thermalfoundation:tool.shears_wood>, [[null,<minecraft:stick>,null],
-	[<minecraft:stick>,null,<minecraft:stick>],
-	[<enderio:item_material:9>,<minecraft:stick>,null]]);
+recipes.addShaped(<thermalfoundation:tool.shears_wood>, [[null,<ore:stickWood>,null],
+	[<ore:stickWood>,null,<ore:stickWood>],
+	[<enderio:item_material:9>,<ore:stickWood>,null]]);
 
 //Fertilizer 
 recipes.addShaped("actuallyadditions_fertilizer", <actuallyadditions:item_fertilizer> * 8, [[<minecraft:sand>,<metaitem:gemApatite>,<minecraft:sand>]]);

--- a/overrides/scripts/Armors.zs
+++ b/overrides/scripts/Armors.zs
@@ -46,7 +46,7 @@ recipes.addShaped(<minecraft:diamond_boots>, [
 // recipes.addShaped(<minecraft:diamond_sword>, [
 //	[null, <metaitem:plateDiamond>, null], 
 //	[null, <metaitem:plateDiamond>, null], 
-//	[null, <minecraft:stick>, null]]);	
+//	[null, <ore:stickWood>, null]]);	
 	
 furnace.addRecipe(<thermalfoundation:material:833>, <metaitem:rubber_drop>, 0.0);
 
@@ -72,7 +72,7 @@ recipes.addShaped(<armorplus:redstone_boots>, [
 recipes.addShaped(<armorplus:redstone_sword>, [
 	[null, <nomilabs:redstonearmorplate>, null], 
 	[null, <nomilabs:redstonearmorplate>, null], 
-	[null, <minecraft:stick>, null]]);	
+	[null, <ore:stickWood>, null]]);	
 	
 //Lapis Armor
 recipes.addShaped(<nomilabs:lapisarmorplate>, [
@@ -96,7 +96,7 @@ recipes.addShaped(<armorplus:lapis_boots>, [
 recipes.addShaped(<armorplus:lapis_sword>, [
 	[null, <nomilabs:lapisarmorplate>, null], 
 	[null, <nomilabs:lapisarmorplate>, null], 
-	[null, <minecraft:stick>, null]]);	
+	[null, <ore:stickWood>, null]]);	
 	
 //Carbon Armor
 recipes.addShaped(<nomilabs:carbonarmorplate>, [
@@ -205,7 +205,7 @@ recipes.addShaped(<armorplus:knight_slime_boots>, [
 //Infused Lava
 var obs = <armorplus:lava_infused_obsidian>;
 var cry = <armorplus:lava_crystal:1>;
-var stick = <minecraft:stick>;
+var stick = <ore:stickWood>;
 mods.extendedcrafting.TableCrafting.addShaped(<armorplus:infused_lava_helmet>, [
 [obs,obs,cry,obs,obs],
 [cry,null,null,null,cry],
@@ -258,7 +258,7 @@ mods.extendedcrafting.TableCrafting.addShaped(<armorplus:obsidian_boots>, [
 recipes.addShaped(<armorplus:obsidian_sword>, [
 	[null, <armorplus:compressed_obsidian>, null], 
 	[null, <armorplus:compressed_obsidian>, null], 
-	[null, <minecraft:stick>, null]]);	
+	[null, <ore:stickWood>, null]]);	
 
 
 //Emerald

--- a/overrides/scripts/electronics.zs
+++ b/overrides/scripts/electronics.zs
@@ -136,9 +136,6 @@ assembler.recipeBuilder()
 //	[<ore:plateWroughtIron>, <ore:plateWroughtIron>, <ore:plateWroughtIron>], 
 //	[<ore:cableGtSingleTin>, <gregtech:machine_casing:1>, <ore:cableGtSingleTin>]]);	
 
-//Wood Pulp
-recipes.addShapeless(<metaitem:dustWood> * 4,[<ore:logWood>,<ore:toolMortar>]);	
-
 //Pyrolyse Oven (moved to groovy)
 
 //// LV Casing

--- a/overrides/scripts/expertmode.zs
+++ b/overrides/scripts/expertmode.zs
@@ -494,7 +494,7 @@ recipes.addShaped(<metaitem:gcym:parallel_hatch.uv>, [
 // Stabilized Miners (Moved to Groovy)
 
 // Remove shortcut recipes
-recipes.remove(<minecraft:stick> * 16);
+recipes.remove(<ore:stickWood> * 16);
 recipes.removeByRecipeName("appliedenergistics2:misc/vanilla_comparator");
 recipes.remove(<minecraft:chest> * 4);
 


### PR DESCRIPTION
This PR makes some small earlygame tweaks to expert mode:

- Adds a Log -> Stick Shortcut Recipe
- Removes Shortcut Paper Recipes
- Makes Wood Pulp Output 2 Instead of 4