### PR TITLE
Allow Usage of Fluid Containers in Crafting

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -229,8 +229,19 @@ crafting.shapedBuilder()
 	.key('C', ore('stick'))
 	.replace().register()
 
-// Firebricks
+// Concrete Cell + Firebricks
 if (LabsModeHelper.expert) {
+	crafting.shapedBuilder()
+		.output(IngredientFluidBucket.fillStack(metaitem('fluid_cell'), fluid('concrete') * 1000))
+		.matrix('ABC', 'ADE', ' F ')
+		.key('A', ore('dustCalcite'))
+		.key('B', metaitem('fluid_cell'))
+		.key('C', ore('dustStone'))
+		.key('D', fluidIng(fluid('water')))
+		.key('E', ore('dustQuartzSand'))
+		.key('F', ore('dustClay'))
+		.replace().register()
+
 	crafting.shapedBuilder()
 		.output(item('gregtech:metal_casing', 1))
 		.matrix('BGB', 'BCB', 'BGB')
@@ -346,9 +357,7 @@ class IngredientFluidBucket extends SimpleIIngredient {
 		List<ItemStack> matchingStacks = [FluidUtil.getFilledBucket(this.stack)]
 
 		for (ItemStack fill : fillables) {
-			var toFill = fill.copy();
-			if (getHandler(toFill)?.fill(this.stack, true) != 0)
-				matchingStacks.add(toFill)
+			matchingStacks.add(fillStack(fill, this.stack))
 		}
 
 		this.matchingStacks = matchingStacks.toArray()
@@ -379,6 +388,12 @@ class IngredientFluidBucket extends SimpleIIngredient {
 		handler.drain(stack, true)
 
 		return handler.getContainer() * 1
+	}
+
+	static ItemStack fillStack(ItemStack itemStack, FluidStack fluidStack) {
+		var toFill = itemStack.copy()
+		getHandler(toFill)?.fill(fluidStack, true)
+		return toFill
 	}
 
 	static IFluidHandlerItem getHandler(ItemStack itemStack) {

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -2,10 +2,15 @@ import com.google.common.base.CaseFormat
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import com.nomiceu.nomilabs.groovy.SimpleIIngredient
 import net.minecraft.item.ItemStack
+import net.minecraftforge.fluids.Fluid
 import net.minecraftforge.fluids.FluidStack
 import net.minecraftforge.fluids.FluidUtil
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler
 import net.minecraftforge.fluids.capability.IFluidHandlerItem
+
+import static com.nomiceu.nomilabs.util.LabsTranslate.Translatable
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translate
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
 
 /*
  * Allows recipes with buckets to accept all fluid containers.
@@ -31,37 +36,46 @@ for (var entry : [0: 'glass', 20: 'covered', 40: 'smart', 60: 'dense_smart', 500
 	}
 
 	crafting.remove("appliedenergistics2:network/cables/${entry.value}_fluix_clean")
-	crafting.addShapeless(output, [cables, fluidIng(fluid('water'))])
+	crafting.shapelessBuilder()
+		.output(output)
+		.input(cables, fluidIng(fluid('water')))
+		.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
+		.replace().register()
 }
 
 // Paper
 crafting.remove('thermalfoundation:paper')
-crafting.addShapeless(item('minecraft:paper') * 2,
-	[ore('dustWood'), ore('dustWood'), ore('dustWood'), ore('dustWood'), fluidIng(fluid('water'))])
+crafting.shapelessBuilder()
+	.output(item('minecraft:paper') * 2)
+	.input(ore('dustWood'), ore('dustWood'), ore('dustWood'), ore('dustWood'), fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.register()
 
 // Podzol
 crafting.remove('thermalfoundation:block_podzol')
-crafting.addShapeless(item('minecraft:dirt', 2), [
-	ore('treeLeaves'),
-	ore('treeLeaves'),
-	item('minecraft:dirt', 1),
-	item('thermalfoundation:fertilizer', 1),
-	fluidIng(fluid('water')),
-])
+crafting.shapelessBuilder()
+	.output(item('minecraft:dirt', 2))
+	.input(ore('treeLeaves'), ore('treeLeaves'), item('minecraft:dirt', 1),
+		item('thermalfoundation:fertilizer', 1), fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.register()
 
 // Mycelium
 crafting.remove('thermalfoundation:block_mycelium')
-crafting.addShapeless(item('minecraft:mycelium'), [
-	item('minecraft:brown_mushroom'),
-	item('minecraft:red_mushroom'),
-	item('minecraft:dirt', 1),
-	item('thermalfoundation:fertilizer', 1),
-	fluidIng(fluid('water')),
-])
+crafting.shapelessBuilder()
+	.output(item('minecraft:mycelium'))
+	.input(item('minecraft:brown_mushroom'), item('minecraft:red_mushroom'), item('minecraft:dirt', 1),
+		item('thermalfoundation:fertilizer', 1), fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.register()
 
 // Little Tiles Water
-crafting.replaceShapeless(item('littletiles:lttransparentcoloredblock', 5) * 2,
-	[fluidIng(fluid('water')), fluidIng(fluid('water'))])
+crafting.shapelessBuilder()
+	.output(item('littletiles:lttransparentcoloredblock', 5) * 2)
+	.input(fluidIng(fluid('water')), fluidIng(fluid('water')))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.replace().register()
 
 // Waterstone
 crafting.shapedBuilder()
@@ -69,6 +83,7 @@ crafting.shapedBuilder()
 	.matrix('AAA', 'ABA', 'AAA')
 	.key('A', item('minecraft:stone'))
 	.key('B', fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.replace().register()
 
 // Water Mob Filter
@@ -79,6 +94,7 @@ crafting.shapedBuilder()
 	.key('A', ore('fenceGateWood'))
 	.key('B', ore('stone'))
 	.key('C', fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.register()
 
 // Rice Slimeball
@@ -88,6 +104,7 @@ crafting.shapedBuilder()
 	.matrix(' A ', 'ABA', ' A ')
 	.key('A', item('actuallyadditions:item_misc', 9))
 	.key('B', fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.register()
 
 // Ring of Liquid Banning
@@ -97,12 +114,19 @@ crafting.shapedBuilder()
 	.key('A', fluidIng(fluid('water')))
 	.key('B', item('actuallyadditions:item_crystal_empowered', 2))
 	.key('C', item('actuallyadditions:item_misc', 6))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(2, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(6, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(8, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.replace().register()
 
 // Red Machine -> Blank Machine
 crafting.remove('enderio:deco_block_1_1_f')
-crafting.addShapeless(item('enderio:block_decoration1', 1),
-	[item('enderio:block_decoration1', 13), fluidIng(fluid('water'))])
+crafting.shapelessBuilder()
+	.output(item('enderio:block_decoration1', 1))
+	.input(item('enderio:block_decoration1', 13), fluidIng(fluid('water')))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.register()
 
 // Hard Mode Recipes
 if (LabsModeHelper.expert) {
@@ -114,6 +138,7 @@ if (LabsModeHelper.expert) {
 		.key('M', ore('toolMallet'))
 		.key('D', ore('dustPaper'))
 		.key('W', fluidIng(fluid('water')))
+		.setInputTooltip(7, IngredientFluidBucket.getInputTooltip(fluid('water')))
 		.register()
 
 	// Bricks
@@ -123,15 +148,20 @@ if (LabsModeHelper.expert) {
 		.matrix('BBB', 'BWB', 'BBB')
 		.key('B', item('minecraft:brick'))
 		.key('W', fluidIng(fluid('water')))
+		.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 		.register()
 
-	// Don't replace concrete, as it consumes a bucket and produces a bucket
+	// Concrete Bucket recipe is changed, see below
 }
 
 /* Lava Bucket */
 
 // Little Tiles Lava
-crafting.replaceShapeless(item('littletiles:ltcoloredblock', 12), [fluidIng(fluid('lava'))])
+crafting.shapelessBuilder()
+	.output(item('littletiles:ltcoloredblock', 12))
+	.input(fluidIng(fluid('lava')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.replace().register()
 
 // Lavastone
 crafting.shapedBuilder()
@@ -139,6 +169,7 @@ crafting.shapedBuilder()
 	.matrix('AAA', 'ABA', 'AAA')
 	.key('A', item('minecraft:stone'))
 	.key('B', fluidIng(fluid('lava')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.replace().register()
 
 // Nullifier
@@ -153,6 +184,7 @@ crafting.shapedBuilder()
 	.key('C', item('thermalexpansion:frame', 64))
 	.key('D', ore('gearIron'))
 	.key('E', item('thermalfoundation:material', 512))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.register()
 
 // Void Satchel
@@ -162,17 +194,24 @@ crafting.shapedBuilder()
 	.key('A', item('minecraft:leather'))
 	.key('B', ore('stone'))
 	.key('C', fluidIng(fluid('lava')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.replace().register()
 
 /* Milk Bucket */
 
 // White Water
-crafting.replaceShapeless(item('littletiles:lttransparentcoloredblock', 6),
-	[fluidIng(fluid('milk')), item('littletiles:lttransparentcoloredblock', 5)])
+crafting.shapelessBuilder()
+	.output(item('littletiles:lttransparentcoloredblock', 6))
+	.input(fluidIng(fluid('milk')), item('littletiles:lttransparentcoloredblock', 5))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.replace().register()
 
 // White Lava
-crafting.replaceShapeless(item('littletiles:ltcoloredblock', 14),
-	[fluidIng(fluid('milk')), item('littletiles:ltcoloredblock', 12)])
+crafting.shapelessBuilder()
+	.output(item('littletiles:ltcoloredblock', 14))
+	.input(fluidIng(fluid('milk')), item('littletiles:ltcoloredblock', 12))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.replace().register()
 
 // Pet Mob Filter
 crafting.remove('darkutils:filter_pet')
@@ -182,14 +221,22 @@ crafting.shapedBuilder()
 	.key('A', ore('fenceGateWood'))
 	.key('B', ore('stone'))
 	.key('C', fluidIng(fluid('milk')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('milk')))
 	.register()
 
 // Chocolate Coin
-crafting.replaceShapeless(metaitem('coin.chocolate'),
-	[ore('dustCocoa'), ore('foilGold'), fluidIng(fluid('milk')), ore('dustSugar')])
+crafting.shapelessBuilder()
+	.output(metaitem('coin.chocolate'))
+	.input(ore('dustCocoa'), ore('foilGold'), fluidIng(fluid('milk')), ore('dustSugar'))
+	.setInputTooltip(3, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.replace().register()
 
 // Cheese
-crafting.replaceShapeless(item('actuallyadditions:item_food'), [fluidIng(fluid('milk')), ore('egg')])
+crafting.shapelessBuilder()
+	.output(item('actuallyadditions:item_food'))
+	.input(fluidIng(fluid('milk')), ore('egg'))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.replace().register()
 
 // Chocolate
 crafting.shapedBuilder()
@@ -197,6 +244,7 @@ crafting.shapedBuilder()
 	.matrix('C C', 'CMC', 'C C')
 	.key('C', item('minecraft:dye', 3))
 	.key('M', fluidIng(fluid('milk')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('milk')))
 	.replace().register()
 
 // Chocolate Cake
@@ -208,6 +256,9 @@ crafting.shapedBuilder()
 	.key('E', ore('egg'))
 	.key('D', ore('dough'))
 	.key('S', ore('dustSugar'))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.setInputTooltip(2, IngredientFluidBucket.getInputTooltip(fluid('milk')))
 	.replace().register()
 
 /* Misc */
@@ -218,6 +269,7 @@ crafting.shapedBuilder()
 	.matrix('AAA', 'ABA', 'AAA')
 	.key('A', ore('plankWood'))
 	.key('B', fluidIng(fluid('creosote')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('creosote')))
 	.replace().register()
 
 // Torch
@@ -227,6 +279,7 @@ crafting.shapedBuilder()
 	.key('A', ore('wool'))
 	.key('B', fluidIng(fluid('creosote')))
 	.key('C', ore('stick'))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('creosote')))
 	.replace().register()
 
 // Concrete Cell + Firebricks
@@ -240,6 +293,7 @@ if (LabsModeHelper.expert) {
 		.key('D', fluidIng(fluid('water')))
 		.key('E', ore('dustQuartzSand'))
 		.key('F', ore('dustClay'))
+		.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 		.replace().register()
 
 	crafting.shapedBuilder()
@@ -248,6 +302,7 @@ if (LabsModeHelper.expert) {
 		.key('B', metaitem('brick.fireclay'))
 		.key('G', ore('dustGypsum'))
 		.key('C', fluidIng(fluid('concrete')))
+		.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('concrete')))
 		.replace().register()
 }
 
@@ -255,7 +310,11 @@ if (LabsModeHelper.expert) {
 
 if (LabsModeHelper.normal) {
 	// Dust -> Clay
-	crafting.addShapeless(item('minecraft:clay'), [item('nomilabs:block_dust'), fluidIng(fluid('water'))])
+	crafting.shapelessBuilder()
+		.output(item('minecraft:clay'))
+		.input(item('nomilabs:block_dust'), fluidIng(fluid('water')))
+		.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
+		.register()
 }
 
 // NC Water Source
@@ -264,6 +323,8 @@ crafting.shapedBuilder()
 	.matrix('AAA', 'B B', 'AAA')
 	.key('A', LabsModeHelper.expert ? ore('plateDoubleSteel') : ore('plateWroughtIron'))
 	.key('B', fluidIng(fluid('water')))
+    .setInputTooltip(3, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(5, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.replace().register()
 
 // NC Cobblestone Generator
@@ -273,6 +334,9 @@ crafting.shapedBuilder()
 	.key('A', LabsModeHelper.expert ? ore('plateBlackSteel') : ore('plateWroughtIron'))
 	.key('B', fluidIng(fluid('water')))
 	.key('C', fluidIng(fluid('lava')))
+	.setInputTooltip(3, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(5, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.setOutputTooltip(translatable('nomiceu.tooltip.mixed.mirrorable'))
 	.replace().mirrored().register()
 
 // Lava Factory
@@ -283,7 +347,9 @@ crafting.shapedBuilder()
 	.key('B', item('actuallyadditions:block_misc', 7)) // Lava Factory Casing
 	.key('C', fluidIng(fluid('lava')))
 	.key('D', item('morefurnaces:furnaceblock', 3)) // Obsidian Furnace
-	.replace().mirrored().register()
+	.setInputTooltip(6, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.setInputTooltip(8, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.replace().register()
 
 // Pyroclastic Injection
 crafting.shapedBuilder()
@@ -292,10 +358,16 @@ crafting.shapedBuilder()
 	.key('A', ore('ingotMithril'))
 	.key('B', ore('plateMithril'))
 	.key('C', fluidIng(fluid('water')))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.replace().register()
 
 // Obsidian Quick Craft
-crafting.addShapeless(item('minecraft:obsidian'), [fluidIng(fluid('water')), fluidIng(fluid('lava'))])
+crafting.shapelessBuilder()
+	.output(item('minecraft:obsidian'))
+	.input(fluidIng(fluid('water')), fluidIng(fluid('lava')))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.register()
 
 // Cake Base
 crafting.shapedBuilder()
@@ -304,6 +376,7 @@ crafting.shapedBuilder()
 	.key('S', ore('dustSugar'))
 	.key('M', fluidIng(fluid('milk')))
 	.key('D', ore('dough'))
+	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('milk')))
 	.replace().register()
 
 // Cake
@@ -314,19 +387,22 @@ crafting.shapedBuilder()
 	.key('S', ore('dustSugar'))
 	.key('E', ore('egg'))
 	.key('D', ore('dough'))
+	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('milk')))
+	.setInputTooltip(2, IngredientFluidBucket.getInputTooltip(fluid('milk')))
 	.replace().register()
 
 /* Classes and Helpers */
 
 // IIngredient Class that Matches Based on FluidStack in Containers
 class IngredientFluidBucket extends SimpleIIngredient {
-	static AMOUNT = 1000
+	public static final AMOUNT = 1000
 	// Example Fills (excludes bucket)
-	private static List<ItemStack> fillables = [
+	private static final List<ItemStack> fillables = [
 		metaitem('fluid_cell'),
 		metaitem('fluid_cell.universal'),
-		metaitem('large_fluid_cell.steel'),
 		metaitem('nomilabs:bronze_cell'),
+		metaitem('large_fluid_cell.steel'),
 		metaitem('large_fluid_cell.aluminium'),
 		metaitem('large_fluid_cell.stainless_steel'),
 		metaitem('large_fluid_cell.titanium'),
@@ -348,8 +424,8 @@ class IngredientFluidBucket extends SimpleIIngredient {
 		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 4]),
 	]
 
-	FluidStack stack
-	ItemStack[] matchingStacks
+	private final FluidStack stack
+	private final ItemStack[] matchingStacks
 
 	IngredientFluidBucket(FluidStack stack) {
 		this.stack = stack * AMOUNT
@@ -357,7 +433,18 @@ class IngredientFluidBucket extends SimpleIIngredient {
 		List<ItemStack> matchingStacks = [FluidUtil.getFilledBucket(this.stack)]
 
 		for (ItemStack fill : fillables) {
-			matchingStacks.add(fillStack(fill, this.stack))
+			var toFill = fill.copy()
+
+			var handler = getHandler(toFill)
+			if (handler == null) continue
+
+			int capacity = handler.tankProperties[0].capacity
+			if (capacity <= 0) capacity = AMOUNT
+
+			int filled = handler.fill(stack * capacity, true)
+
+			if (filled == capacity)
+				matchingStacks.add(toFill)
 		}
 
 		this.matchingStacks = matchingStacks.toArray()
@@ -408,6 +495,31 @@ class IngredientFluidBucket extends SimpleIIngredient {
 			handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)
 		}
 		return handler
+	}
+
+	static Translatable[] getInputTooltip(FluidStack fluidStack) {
+		return new Translatable[] {
+			new TranslatableFluidTooltip(fluidStack.fluid),
+			translatable('nomiceu.tooltip.mixed.accepts_fluid_container')
+		}
+	}
+}
+
+/**
+ * Simple wrapper class so we can use translated name of fluid in tooltip
+ */
+class TranslatableFluidTooltip extends Translatable {
+	Fluid fluid
+
+	TranslatableFluidTooltip(Fluid fluid) {
+		super('nomiceu.tooltip.mixed.accepts_fluid')
+		this.fluid = fluid
+	}
+
+	@Override
+	protected String translateThis() {
+		String fluidName = translate(fluid.unlocalizedName)
+		return translate(key, fluidName)
 	}
 }
 

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -1,3 +1,4 @@
+import com.google.common.base.CaseFormat
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import com.nomiceu.nomilabs.groovy.SimpleIIngredient
 import net.minecraft.item.ItemStack
@@ -7,17 +8,237 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler
 import net.minecraftforge.fluids.capability.IFluidHandlerItem
 
 /*
- * Allows Recipes with Water/Lava Bucket to Accept All Fluid Containers.
+ * Allows recipes with buckets to accept all fluid containers.
  * Also adds other misc. fluid crafting recipes.
  */
 
-/* Existing Replacements */
+/* Starter OreDicts */
+ore('dough').add(item('actuallyadditions:item_misc', 4))
+ore('dough').add(item('actuallyadditions:item_misc', 9))
 
-// Water Bucket
+/* Existing Replacements (Recipe itself not changed) */
 
-// Lava Bucket
+/* Water Bucket */
 
-// Milk Bucket
+// AE2 Cable Cleaning
+var caseConverter = CaseFormat.LOWER_UNDERSCORE.converterTo(CaseFormat.UPPER_CAMEL)
+for (var entry : [0: 'glass', 20: 'covered', 40: 'smart', 60: 'dense_smart', 500: 'dense_covered']) {
+	var cables = ore("ae2Colored${caseConverter.convert(entry.value)}Cable")
+	var output = item('appliedenergistics2:part', entry.key + 16)
+
+	for (var meta : entry.key..entry.key + 15) {
+		cables.add(item('appliedenergistics2:part', meta))
+	}
+
+	crafting.remove("appliedenergistics2:network/cables/${entry.value}_fluix_clean")
+	crafting.addShapeless(output, [cables, fluidIng(fluid('water'))])
+}
+
+// Paper
+crafting.remove('thermalfoundation:paper')
+crafting.addShapeless(item('minecraft:paper') * 2,
+	[ore('dustWood'), ore('dustWood'), ore('dustWood'), ore('dustWood'), fluidIng(fluid('water'))])
+
+// Podzol
+crafting.remove('thermalfoundation:block_podzol')
+crafting.addShapeless(item('minecraft:dirt', 2), [
+	ore('treeLeaves'),
+	ore('treeLeaves'),
+	item('minecraft:dirt', 1),
+	item('thermalfoundation:fertilizer', 1),
+	fluidIng(fluid('water')),
+])
+
+// Mycelium
+crafting.remove('thermalfoundation:block_mycelium')
+crafting.addShapeless(item('minecraft:mycelium'), [
+	item('minecraft:brown_mushroom'),
+	item('minecraft:red_mushroom'),
+	item('minecraft:dirt', 1),
+	item('thermalfoundation:fertilizer', 1),
+	fluidIng(fluid('water')),
+])
+
+// Little Tiles Water
+crafting.replaceShapeless(item('littletiles:lttransparentcoloredblock', 5) * 2,
+	[fluidIng(fluid('water')), fluidIng(fluid('water'))])
+
+// Waterstone
+crafting.shapedBuilder()
+	.output(item('chisel:waterstone') * 8)
+	.matrix('AAA', 'ABA', 'AAA')
+	.key('A', item('minecraft:stone'))
+	.key('B', fluidIng(fluid('water')))
+	.replace().register()
+
+// Water Mob Filter
+crafting.remove('darkutils:filter_water')
+crafting.shapedBuilder()
+	.output(item('darkutils:filter', 5) * 4)
+	.matrix('ABA', 'BCB', 'ABA')
+	.key('A', ore('fenceGateWood'))
+	.key('B', ore('stone'))
+	.key('C', fluidIng(fluid('water')))
+	.register()
+
+// Rice Slimeball
+crafting.remove('actuallyadditions:recipes24')
+crafting.shapedBuilder()
+	.output(item('actuallyadditions:item_misc', 12) * 4)
+	.matrix(' A ', 'ABA', ' A ')
+	.key('A', item('actuallyadditions:item_misc', 9))
+	.key('B', fluidIng(fluid('water')))
+	.register()
+
+// Ring of Liquid Banning
+crafting.shapedBuilder()
+	.output(item('actuallyadditions:item_water_removal_ring'))
+	.matrix('ABA', 'BCB', 'ABA')
+	.key('A', fluidIng(fluid('water')))
+	.key('B', item('actuallyadditions:item_crystal_empowered', 2))
+	.key('C', item('actuallyadditions:item_misc', 6))
+	.replace().register()
+
+// Red Machine -> Blank Machine
+crafting.remove('enderio:deco_block_1_1_f')
+crafting.addShapeless(item('enderio:block_decoration1', 1),
+	[item('enderio:block_decoration1', 13), fluidIng(fluid('water'))])
+
+// Hard Mode Recipes
+if (LabsModeHelper.expert) {
+	// Paper
+	crafting.remove('gregtech:paper')
+	crafting.shapedBuilder()
+		.output(item('minecraft:paper') * 2)
+		.matrix(' M ', 'DDD', ' W ')
+		.key('M', ore('toolMallet'))
+		.key('D', ore('dustPaper'))
+		.key('W', fluidIng(fluid('water')))
+		.register()
+
+	// Bricks
+	crafting.remove('gregtech:brick_from_water')
+	crafting.shapedBuilder()
+		.output(item('minecraft:brick_block') * 2)
+		.matrix('BBB', 'BWB', 'BBB')
+		.key('B', item('minecraft:brick'))
+		.key('W', fluidIng(fluid('water')))
+		.register()
+
+	// Don't replace concrete, as it consumes a bucket and produces a bucket
+}
+
+/* Lava Bucket */
+
+// Little Tiles Lava
+crafting.replaceShapeless(item('littletiles:ltcoloredblock', 12), [fluidIng(fluid('lava'))])
+
+// Lavastone
+crafting.shapedBuilder()
+	.output(item('chisel:lavastone') * 8)
+	.matrix('AAA', 'ABA', 'AAA')
+	.key('A', item('minecraft:stone'))
+	.key('B', fluidIng(fluid('lava')))
+	.replace().register()
+
+// Nullifier
+crafting.removeByOutput(item('thermalexpansion:device', 1))
+crafting.shapedBuilder()
+	.output(item('thermalexpansion:device', 1)
+		.withNbt(['Facing': (byte) 3, 'SideCache': [(byte) 0, (byte) 1, (byte) 1, (byte) 1, (byte) 1, (byte) 1],
+				  'RSControl': (byte) 0, 'Energy': 0]))
+	.matrix(' A ', 'BCB', 'DED')
+	.key('A', fluidIng(fluid('lava')))
+	.key('B', item('minecraft:brick_block'))
+	.key('C', item('thermalexpansion:frame', 64))
+	.key('D', ore('gearIron'))
+	.key('E', item('thermalfoundation:material', 512))
+	.register()
+
+// Void Satchel
+crafting.shapedBuilder()
+	.output(item('thermalexpansion:satchel', 100))
+	.matrix(' A ', 'BCB', 'A A')
+	.key('A', item('minecraft:leather'))
+	.key('B', ore('stone'))
+	.key('C', fluidIng(fluid('lava')))
+	.replace().register()
+
+/* Milk Bucket */
+
+// White Water
+crafting.replaceShapeless(item('littletiles:lttransparentcoloredblock', 6),
+	[fluidIng(fluid('milk')), item('littletiles:lttransparentcoloredblock', 5)])
+
+// White Lava
+crafting.replaceShapeless(item('littletiles:ltcoloredblock', 14),
+	[fluidIng(fluid('milk')), item('littletiles:ltcoloredblock', 12)])
+
+// Pet Mob Filter
+crafting.remove('darkutils:filter_pet')
+crafting.shapedBuilder()
+	.output(item('darkutils:filter', 7) * 4)
+	.matrix('ABA', 'BCB', 'ABA')
+	.key('A', ore('fenceGateWood'))
+	.key('B', ore('stone'))
+	.key('C', fluidIng(fluid('milk')))
+	.register()
+
+// Chocolate Coin
+crafting.replaceShapeless(metaitem('coin.chocolate'),
+	[ore('dustCocoa'), ore('foilGold'), fluidIng(fluid('milk')), ore('dustSugar')])
+
+// Cheese
+crafting.replaceShapeless(item('actuallyadditions:item_food'), [fluidIng(fluid('milk')), ore('egg')])
+
+// Chocolate
+crafting.shapedBuilder()
+	.output(item('actuallyadditions:item_food', 9) * 3)
+	.matrix('C C', 'CMC', 'C C')
+	.key('C', item('minecraft:dye', 3))
+	.key('M', fluidIng(fluid('milk')))
+	.replace().register()
+
+// Chocolate Cake
+crafting.shapedBuilder()
+	.output(item('actuallyadditions:item_food', 8))
+	.matrix('MMM', 'CCC', 'EDS')
+	.key('M', fluidIng(fluid('milk')))
+	.key('C', item('minecraft:dye', 3))
+	.key('E', ore('egg'))
+	.key('D', ore('dough'))
+	.key('S', ore('dustSugar'))
+	.replace().register()
+
+/* Misc */
+
+// Treated Wood
+crafting.shapedBuilder()
+	.output(item('gregtech:planks', 1) * 8)
+	.matrix('AAA', 'ABA', 'AAA')
+	.key('A', ore('plankWood'))
+	.key('B', fluidIng(fluid('creosote')))
+	.replace().register()
+
+// Torch
+crafting.shapedBuilder()
+	.output(item('minecraft:torch') * 16)
+	.matrix('AB', 'C ')
+	.key('A', ore('wool'))
+	.key('B', fluidIng(fluid('creosote')))
+	.key('C', ore('stick'))
+	.replace().register()
+
+// Firebricks
+if (LabsModeHelper.expert) {
+	crafting.shapedBuilder()
+		.output(item('gregtech:metal_casing', 1))
+		.matrix('BGB', 'BCB', 'BGB')
+		.key('B', metaitem('brick.fireclay'))
+		.key('G', ore('dustGypsum'))
+		.key('C', fluidIng(fluid('concrete')))
+		.replace().register()
+}
 
 /* New Recipes */
 
@@ -29,75 +250,112 @@ if (LabsModeHelper.normal) {
 // NC Water Source
 crafting.shapedBuilder()
 	.output(item('nuclearcraft:water_source'))
-	.matrix(
-		'AAA',
-		'B B',
-		'AAA')
+	.matrix('AAA', 'B B', 'AAA')
 	.key('A', LabsModeHelper.expert ? ore('plateDoubleSteel') : ore('plateWroughtIron'))
 	.key('B', fluidIng(fluid('water')))
-	.replace()
-	.register()
+	.replace().register()
 
 // NC Cobblestone Generator
 crafting.shapedBuilder()
 	.output(item('nuclearcraft:cobblestone_generator'))
-	.matrix(
-		'AAA',
-		'B C',
-		'AAA')
+	.matrix('AAA', 'B C', 'AAA')
 	.key('A', LabsModeHelper.expert ? ore('plateBlackSteel') : ore('plateWroughtIron'))
 	.key('B', fluidIng(fluid('water')))
 	.key('C', fluidIng(fluid('lava')))
-	.replace()
-	.mirrored()
-	.register()
+	.replace().mirrored().register()
 
 // Lava Factory
 crafting.shapedBuilder()
 	.output(item('actuallyadditions:block_lava_factory_controller'))
-	.matrix(
-		'ABA',
-		'CDC')
+	.matrix('ABA', 'CDC')
 	.key('A', item('actuallyadditions:item_misc', 8)) // Advanced Coil
 	.key('B', item('actuallyadditions:block_misc', 7)) // Lava Factory Casing
 	.key('C', fluidIng(fluid('lava')))
 	.key('D', item('morefurnaces:furnaceblock', 3)) // Obsidian Furnace
-	.replace()
-	.mirrored()
-	.register()
+	.replace().mirrored().register()
 
 // Pyroclastic Injection
 crafting.shapedBuilder()
 	.output(item('thermalexpansion:augment', 496))
-	.matrix(
-		'ABA',
-		'BCB',
-		'ABA')
+	.matrix('ABA', 'BCB', 'ABA')
 	.key('A', ore('ingotMithril'))
 	.key('B', ore('plateMithril'))
 	.key('C', fluidIng(fluid('water')))
-	.replace()
-	.register()
+	.replace().register()
 
 // Obsidian Quick Craft
 crafting.addShapeless(item('minecraft:obsidian'), [fluidIng(fluid('water')), fluidIng(fluid('lava'))])
+
+// Cake Base
+crafting.shapedBuilder()
+	.output(item('enderio:item_material', 70))
+	.matrix('SMS', 'DDD')
+	.key('S', ore('dustSugar'))
+	.key('M', fluidIng(fluid('milk')))
+	.key('D', ore('dough'))
+	.replace().register()
+
+// Cake
+crafting.shapedBuilder()
+	.output(item('minecraft:cake'))
+	.matrix('BBB', 'SES', 'DDD')
+	.key('B', fluidIng(fluid('milk')))
+	.key('S', ore('dustSugar'))
+	.key('E', ore('egg'))
+	.key('D', ore('dough'))
+	.replace().register()
 
 /* Classes and Helpers */
 
 // IIngredient Class that Matches Based on FluidStack in Containers
 class IngredientFluidBucket extends SimpleIIngredient {
 	static AMOUNT = 1000
+	// Example Fills (excludes bucket)
+	private static List<ItemStack> fillables = [
+		metaitem('fluid_cell'),
+		metaitem('fluid_cell.universal'),
+		metaitem('large_fluid_cell.steel'),
+		metaitem('nomilabs:bronze_cell'),
+		metaitem('large_fluid_cell.aluminium'),
+		metaitem('large_fluid_cell.stainless_steel'),
+		metaitem('large_fluid_cell.titanium'),
+		metaitem('large_fluid_cell.tungstensteel'),
+		metaitem('fluid_cell.glass_vial'),
+		metaitem('drum.bronze'),
+		metaitem('drum.gold'),
+		metaitem('drum.steel'),
+		metaitem('drum.aluminium'),
+		metaitem('drum.stainless_steel'),
+		metaitem('drum.titanium'),
+		metaitem('drum.tungstensteel'),
+		item('enderio:block_tank'),
+		item('enderio:block_tank', 1),
+		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 0]),
+		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 1]),
+		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 2]),
+		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 3]),
+		item('thermalexpansion:tank').withNbt(['RSControl': (byte) 0, 'Creative': (byte) 0, 'Level': (byte) 4]),
+	]
 
 	FluidStack stack
-	ItemStack bucketForm
+	ItemStack[] matchingStacks
 
 	IngredientFluidBucket(FluidStack stack) {
 		this.stack = stack * AMOUNT
-		this.bucketForm = FluidUtil.getFilledBucket(stack)
+
+		List<ItemStack> matchingStacks = [FluidUtil.getFilledBucket(this.stack)]
+
+		for (ItemStack fill : fillables) {
+			var toFill = fill.copy();
+			if (getHandler(toFill)?.fill(this.stack, true) != 0)
+				matchingStacks.add(toFill)
+		}
+
+		this.matchingStacks = matchingStacks.toArray()
 	}
 
 	@Override
-	ItemStack[] getMatchingStacks() { return new ItemStack[]{ bucketForm } }
+	ItemStack[] getMatchingStacks() { return matchingStacks }
 
 	@Override
 	boolean test(ItemStack itemStack) {

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -1,0 +1,143 @@
+import com.nomiceu.nomilabs.util.LabsModeHelper
+import com.nomiceu.nomilabs.groovy.SimpleIIngredient
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fluids.FluidStack
+import net.minecraftforge.fluids.FluidUtil
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler
+import net.minecraftforge.fluids.capability.IFluidHandlerItem
+
+/*
+ * Allows Recipes with Water/Lava Bucket to Accept All Fluid Containers.
+ * Also adds other misc. fluid crafting recipes.
+ */
+
+/* Existing Replacements */
+
+// Water Bucket
+
+// Lava Bucket
+
+// Milk Bucket
+
+/* New Recipes */
+
+if (LabsModeHelper.normal) {
+	// Dust -> Clay
+	crafting.addShapeless(item('minecraft:clay'), [item('nomilabs:block_dust'), fluidIng(fluid('water'))])
+}
+
+// NC Water Source
+crafting.shapedBuilder()
+	.output(item('nuclearcraft:water_source'))
+	.matrix(
+		'AAA',
+		'B B',
+		'AAA')
+	.key('A', LabsModeHelper.expert ? ore('plateDoubleSteel') : ore('plateWroughtIron'))
+	.key('B', fluidIng(fluid('water')))
+	.replace()
+	.register()
+
+// NC Cobblestone Generator
+crafting.shapedBuilder()
+	.output(item('nuclearcraft:cobblestone_generator'))
+	.matrix(
+		'AAA',
+		'B C',
+		'AAA')
+	.key('A', LabsModeHelper.expert ? ore('plateBlackSteel') : ore('plateWroughtIron'))
+	.key('B', fluidIng(fluid('water')))
+	.key('C', fluidIng(fluid('lava')))
+	.replace()
+	.mirrored()
+	.register()
+
+// Lava Factory
+crafting.shapedBuilder()
+	.output(item('actuallyadditions:block_lava_factory_controller'))
+	.matrix(
+		'ABA',
+		'CDC')
+	.key('A', item('actuallyadditions:item_misc', 8)) // Advanced Coil
+	.key('B', item('actuallyadditions:block_misc', 7)) // Lava Factory Casing
+	.key('C', fluidIng(fluid('lava')))
+	.key('D', item('morefurnaces:furnaceblock', 3)) // Obsidian Furnace
+	.replace()
+	.mirrored()
+	.register()
+
+// Pyroclastic Injection
+crafting.shapedBuilder()
+	.output(item('thermalexpansion:augment', 496))
+	.matrix(
+		'ABA',
+		'BCB',
+		'ABA')
+	.key('A', ore('ingotMithril'))
+	.key('B', ore('plateMithril'))
+	.key('C', fluidIng(fluid('water')))
+	.replace()
+	.register()
+
+// Obsidian Quick Craft
+crafting.addShapeless(item('minecraft:obsidian'), [fluidIng(fluid('water')), fluidIng(fluid('lava'))])
+
+/* Classes and Helpers */
+
+// IIngredient Class that Matches Based on FluidStack in Containers
+class IngredientFluidBucket extends SimpleIIngredient {
+	static AMOUNT = 1000
+
+	FluidStack stack
+	ItemStack bucketForm
+
+	IngredientFluidBucket(FluidStack stack) {
+		this.stack = stack * AMOUNT
+		this.bucketForm = FluidUtil.getFilledBucket(stack)
+	}
+
+	@Override
+	ItemStack[] getMatchingStacks() { return new ItemStack[]{ bucketForm } }
+
+	@Override
+	boolean test(ItemStack itemStack) {
+		var handler = getHandler(itemStack)
+
+		if (handler == null) return false
+
+		FluidStack drained = handler.drain(stack, false)
+		return drained != null && drained.amount >= AMOUNT && drained.isFluidEqual(stack)
+	}
+
+	@Override
+	ItemStack applyTransform(ItemStack matchedInput) {
+		matchedInput = matchedInput.copy()
+
+		if (matchedInput.getItem().hasContainerItem(matchedInput))
+			return super.applyTransform(matchedInput)
+
+		var handler = getHandler(matchedInput)
+		if (handler == null) return super.applyTransform(matchedInput)
+		handler.drain(stack, true)
+
+		return handler.getContainer() * 1
+	}
+
+	static IFluidHandlerItem getHandler(ItemStack itemStack) {
+		if (itemStack.isEmpty()) return null
+
+		IFluidHandlerItem handler = null
+		if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+			if (itemStack.getCount() > 1) {
+				itemStack = itemStack.copy()
+				itemStack.setCount(1)
+			}
+			handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)
+		}
+		return handler
+	}
+}
+
+static IngredientFluidBucket fluidIng(FluidStack stack) {
+	return new IngredientFluidBucket(stack)
+}

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/nbtClearing.groovy
@@ -105,6 +105,19 @@ for (def material : ["wood", "bronze", "steel", "aluminium", "stainless_steel", 
     clearableContainers.add(metaitem("drum.${material}"))
 }
 
+// Cells
+
+// Bronze Cell does not need tooltip added, its recipe is added above
+
+// Special Cells
+clearableContainers.add(metaitem('fluid_cell'))
+clearableContainers.add(metaitem('fluid_cell.universal'))
+
+// Material Cells
+for (def material : ["steel", "aluminium", "stainless_steel", "titanium", "tungstensteel"]) {
+	clearableContainers.add(metaitem("large_fluid_cell.${material}"))
+}
+
 // EIO Tanks
 // Technically Machines Too... but Not As Useful
 clearableContainers.add(item('enderio:block_tank'))

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/tooltips.groovy
@@ -24,6 +24,7 @@ List<ItemStack> fillable = [
 	metaitem('large_fluid_cell.titanium'),
 	metaitem('large_fluid_cell.tungstensteel'),
 	metaitem('fluid_cell.glass_vial'),
+	metaitem('nomilabs:bronze_cell'),
 	item('minecraft:bucket'),
 	item('minecraft:water_bucket'),
 	item('minecraft:lava_bucket'),

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/ae2/blocks.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/ae2/blocks.groovy
@@ -154,7 +154,7 @@ mods.gregtech.wiremill.recipeBuilder()
 	.buildAndRegister()
 
 // Glass Cable
-crafting.removeByOutput(item('appliedenergistics2:part', 16))
+crafting.remove('appliedenergistics2:network/cables/glass_fluix')
 mods.gregtech.alloy_smelter.recipeBuilder()
 	.inputs(ore('dustFluix'), item('appliedenergistics2:part', 140))
 	.outputs(item('appliedenergistics2:part', 16) * 2)
@@ -162,6 +162,7 @@ mods.gregtech.alloy_smelter.recipeBuilder()
 	.buildAndRegister()
 
 // Covered Cable
+crafting.remove('appliedenergistics2:network/cables/covered_fluix')
 for (var rubber in [fluid('rubber') * 144, fluid('styrene_butadiene_rubber') * 36, fluid('silicone_rubber') * 76]) {
 	mods.gregtech.assembler.recipeBuilder()
 		.inputs(item('appliedenergistics2:part', 16))
@@ -169,7 +170,6 @@ for (var rubber in [fluid('rubber') * 144, fluid('styrene_butadiene_rubber') * 3
 		.outputs(item('appliedenergistics2:part', 36))
 		.duration(100).EUt(VA[ULV])
 		.buildAndRegister()
-
 }
 
 // ME Conduit

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -56,6 +56,9 @@ hideItemIgnoreNBT(item('forge:bucketfilled'))
 // Add back Creosote Bucket, has usages in recipes and furnace
 mods.jei.ingredient.add(FluidUtil.getFilledBucket(fluid('creosote') * 1000))
 
+// Add Concrete Cell to JEI
+mods.jei.ingredient.add(metaitem('fluid_cell').withNbt(['Fluid': ['FluidName': 'concrete', 'Amount': 1000]]))
+
 /* Remove Categories (Appear Randomly after /gs reload) */
 // Avatitia
 mods.jei.category.hideCategory('Avatitia.Extreme')

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -56,10 +56,6 @@ hideItemIgnoreNBT(item('forge:bucketfilled'))
 // Add back Creosote Bucket, has usages in recipes and furnace
 mods.jei.ingredient.add(FluidUtil.getFilledBucket(fluid('creosote') * 1000))
 
-// Add back Concrete Bucket, used in Firebricks
-if (LabsModeHelper.expert)
-	mods.jei.ingredient.add(FluidUtil.getFilledBucket(fluid('concrete') * 1000))
-
 /* Remove Categories (Appear Randomly after /gs reload) */
 // Avatitia
 mods.jei.category.hideCategory('Avatitia.Extreme')

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -5,6 +5,9 @@ nomifactory.nonetherportals=Nether portals are disabled in §5Nomi-CEu§r. Follo
 
 # Mixed
 nomiceu.tooltip.mixed.fillable=Can be filled with the §bCanning Machine§r.
+nomiceu.tooltip.mixed.mirrorable=§7Recipe can be mirrored.§r
+nomiceu.tooltip.mixed.accepts_fluid=§7Fluid: §b%s§r
+nomiceu.tooltip.mixed.accepts_fluid_container=§7Accepts §aBuckets§7, §aCells§7, §aDrums§7, and other §aFluid Containers§7!
 
 # MC
 nomiceu.tooltip.mc.xp_bottle=§eGives 25 XP, or one XP Level!§r

--- a/overrides/scripts/Alchemy.zs
+++ b/overrides/scripts/Alchemy.zs
@@ -25,14 +25,6 @@ recipes.remove(<dimensionaledibles:nether_cake>);
 recipes.remove(<dimensionaledibles:end_cake>);
 recipes.remove(<dimensionaledibles:island_cake>);
 recipes.remove(<dimensionaledibles:custom_cake>);
-recipes.remove(<minecraft:cake>);
-recipes.remove(<enderio:item_material:70>);
-
-//Cake Base
-recipes.addShaped(<enderio:item_material:70>, [[<minecraft:sugar>, <minecraft:milk_bucket> | <minecraft:bucket>, <minecraft:sugar>], [<actuallyadditions:item_misc:4> | <actuallyadditions:item_misc:9>, <actuallyadditions:item_misc:4> | <actuallyadditions:item_misc:9>, <actuallyadditions:item_misc:4> | <actuallyadditions:item_misc:9>]]);
-
-//Cake
-recipes.addShaped(<minecraft:cake>, [[<minecraft:milk_bucket> | <minecraft:bucket>, <minecraft:milk_bucket> | <minecraft:bucket>, <minecraft:milk_bucket> | <minecraft:bucket>], [<minecraft:sugar>, <ore:egg>, <minecraft:sugar>], [<actuallyadditions:item_misc:4>,<actuallyadditions:item_misc:4>,<actuallyadditions:item_misc:4>]]);
 
 //Overworld Cake
 recipes.addShaped(<dimensionaledibles:overworld_cake>, [[<minecraft:redstone>, <metaitem:dustGold>, <minecraft:redstone>], [<ore:treeSapling>, <enderio:item_material:70>, <ore:treeSapling>],[<metaitem:plant_ball>,<minecraft:diamond>,<metaitem:plant_ball>]]);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -225,14 +225,9 @@ chemical_reactor.recipeBuilder()
 //Remove other recipe for Dimethylhydrazine
 chemical_reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();
 
-//Lava Factory
+//Lava Factory Casing
 recipes.remove(<actuallyadditions:block_misc:7>);
 recipes.addShaped(<actuallyadditions:block_misc:7> * 2, [[<metaitem:plateAluminium>, <metaitem:plateSteel>, <metaitem:plateAluminium>],[<metaitem:plateSteel>, null, <metaitem:plateSteel>], [<metaitem:plateAluminium>, <metaitem:plateSteel>, <metaitem:plateAluminium>]]);
-
-recipes.remove(<actuallyadditions:block_lava_factory_controller>);
-recipes.addShaped(<actuallyadditions:block_lava_factory_controller>, [
-	[<actuallyadditions:item_misc:8>, <actuallyadditions:block_misc:7>, <actuallyadditions:item_misc:8>],
-	[<minecraft:lava_bucket:*>, <morefurnaces:furnaceblock:3>, <minecraft:lava_bucket:*>]]);
 
 recipes.remove(<actuallyadditions:block_fluid_collector>);
 recipes.remove(<actuallyadditions:block_placer>);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -163,7 +163,6 @@ macerator.recipeBuilder().inputs([<enderio:item_material:19>]).outputs([<enderio
 macerator.recipeBuilder().inputs([<enderio:item_material:15>]).outputs([<enderio:item_material:35>]).duration(300).EUt(16).buildAndRegister();
 macerator.recipeBuilder().inputs([<enderio:item_material:14>]).outputs([<enderio:item_material:36>]).duration(200).EUt(16).buildAndRegister();
 macerator.recipeBuilder().inputs([<enderio:item_material:17>]).outputs([<nomilabs:grainsofinnocence>]).duration(200).EUt(16).buildAndRegister();
-recipes.remove(<appliedenergistics2:part:36>);
 
 //Yeta Wrench
 recipes.remove(<enderio:item_yeta_wrench>);

--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -169,14 +169,6 @@ recipes.addShaped(<thermalexpansion:augment:337>, [
 	[<thermalfoundation:material:328>, <metaitem:gearDiamond>, <thermalfoundation:material:328>],
 	[<thermalfoundation:material:136>, <thermalfoundation:material:328>, <thermalfoundation:material:136>]]);
 
-
-//Pyroconductive Loop
-recipes.remove(<thermalexpansion:augment:352>);
-recipes.addShaped(<thermalexpansion:augment:352>, [
-	[<thermalfoundation:material:136>, <thermalfoundation:material:328>, <thermalfoundation:material:136>],
-	[<thermalfoundation:material:328>, <minecraft:lava_bucket>, <thermalfoundation:material:328>],
-	[<thermalfoundation:material:136>, <thermalfoundation:material:328>, <thermalfoundation:material:136>]]);
-
 //charger thing
 recipes.remove(<thermalexpansion:augment:400>);
 recipes.addShaped(<thermalexpansion:augment:400>, [
@@ -211,13 +203,6 @@ recipes.addShaped(<thermalexpansion:augment:656>, [
 	[<ore:ingotDarkSteel>, <metaitem:nomilabs:plateDarkSteel>, <ore:ingotDarkSteel>],
 	[<metaitem:nomilabs:plateDarkSteel>, <thermalfoundation:material:1024>, <metaitem:nomilabs:plateDarkSteel>],
 	[<ore:ingotDarkSteel>, <metaitem:nomilabs:plateDarkSteel>, <ore:ingotDarkSteel>]]);
-
-	//i give up
-recipes.remove(<thermalexpansion:augment:496>);
-recipes.addShaped(<thermalexpansion:augment:496>, [
-	[<thermalfoundation:material:136>, <thermalfoundation:material:328>, <thermalfoundation:material:136>],
-	[<thermalfoundation:material:328>, <minecraft:water_bucket>, <thermalfoundation:material:328>],
-	[<thermalfoundation:material:136>, <thermalfoundation:material:328>, <thermalfoundation:material:136>]]);
 
 	//i give up
 recipes.remove(<thermalexpansion:augment:688>);

--- a/overrides/scripts/expertmode.zs
+++ b/overrides/scripts/expertmode.zs
@@ -135,15 +135,6 @@ makeShaped("exchangertool", <buildinggadgets:exchangertool>.withTag({blockstate:
 	  R : <ore:dustRedstone>,
 	  I : <ore:ingotIron>}); 
 
-
-recipes.remove(<nuclearcraft:water_source>);
-makeShaped("of_nc_water_source", <nuclearcraft:water_source>,
-    ["AAA",
-     "B B",
-     "AAA"],
-    { A : <ore:plateDoubleSteel>,
-      B : <minecraft:water_bucket:*> });
-
 // XP Juice
 mixer.recipeBuilder()
 	.inputs(<ore:itemPulsatingPowder>)
@@ -313,26 +304,6 @@ recipes.addShaped(<storagedrawers:upgrade_template> * 4, [
 
 recipes.addShaped(<storagedrawers:upgrade_storage:3>, [[<ore:stickWood>, <ore:stickWood>, <ore:stickWood>], [<ore:ingotAluminium>, <storagedrawers:upgrade_template>, <ore:ingotAluminium>], [<ore:stickWood>, <ore:stickWood>, <ore:stickWood>]]);
 recipes.addShaped(<storagedrawers:upgrade_storage:4>, [[<ore:stickWood>, <ore:stickWood>, <ore:stickWood>], [<ore:ingotVibrantAlloy>, <storagedrawers:upgrade_template>, <ore:ingotVibrantAlloy>], [<ore:stickWood>, <ore:stickWood>, <ore:stickWood>]]);
-
-// NC Cobble gen
-recipes.remove(<nuclearcraft:cobblestone_generator>);
-makeShaped("of_nc_cobblestone_generator",
-    <nuclearcraft:cobblestone_generator>,
-    ["AAA",
-     "B C",
-     "AAA"],
-    { A : <ore:plateBlackSteel>,
-      B : <minecraft:water_bucket:*>,
-      C : <minecraft:lava_bucket:*> });
-
-makeShaped("of_nc_cobblestone_generator_mirrored",
-    <nuclearcraft:cobblestone_generator>,
-    ["AAA",
-     "C B",
-     "AAA"],
-    { A : <ore:plateBlackSteel>,
-      B : <minecraft:water_bucket:*>,
-      C : <minecraft:lava_bucket:*> });
 
 //Crystal Growth Chamber
 recipes.addShaped(<ae2stuff:grower>, [

--- a/overrides/scripts/normalmode.zs
+++ b/overrides/scripts/normalmode.zs
@@ -31,8 +31,6 @@ furnace.addRecipe(<metaitem:ingotWroughtIron>, <minecraft:iron_ingot>, 0.0);
 //Red Alloy Dust
 recipes.addShapeless(<metaitem:dustRedAlloy>, [<metaitem:dustCopper>, <minecraft:redstone>, <minecraft:redstone>, <minecraft:redstone>, <minecraft:redstone>]);
 
-recipes.addShapeless(<minecraft:clay>, [<nomilabs:block_dust>,<minecraft:water_bucket>]);
-
 //Clay Electrolyzing
 electrolyzer.findRecipe(60, [<metaitem:dustClay> * 13], [null]).remove();
 electrolyzer.recipeBuilder().inputs([<metaitem:dustClay> * 13]).outputs([<metaitem:dustSodium> * 2, <metaitem:dustSilicon> * 2, <metaitem:dustLithium>, <metaitem:dustAluminium> * 2]).fluidOutputs([<liquid:water>*6000]).duration(364).EUt(15).buildAndRegister();
@@ -331,14 +329,6 @@ makeShaped("of_dml_living_matter_extraterrestrial",
 	  E : <minecraft:ender_pearl> }
 );
 
-recipes.remove(<nuclearcraft:water_source>);
-makeShaped("of_nc_water_source", <nuclearcraft:water_source>,
-    ["AAA",
-     "B B",
-     "AAA"],
-    { A : <ore:plateWroughtIron>,
-      B : <minecraft:water_bucket:*> });
-
 
 //Rubber by hand
 recipes.addShaped(<metaitem:plateRubber>,[[<ore:toolHammer>],[<metaitem:rubber_drop>],[<metaitem:rubber_drop>]]);	
@@ -560,26 +550,6 @@ recipes.addShaped(<storagedrawers:upgrade_template> * 2, [
 	[<ore:stickWood>, <ore:stickWood>, <ore:stickWood>],
 	[<ore:stickWood>, <storagedrawers:customdrawers>, <ore:stickWood>],
 	[<ore:stickWood>, <ore:stickWood>, <ore:stickWood>]]);
-
-// NC Cobble gen
-recipes.remove(<nuclearcraft:cobblestone_generator>);
-makeShaped("of_nc_cobblestone_generator",
-    <nuclearcraft:cobblestone_generator>,
-    ["AAA",
-     "B C",
-     "AAA"],
-    { A : <ore:plateSteel>,
-      B : <minecraft:water_bucket:*>,
-      C : <minecraft:lava_bucket:*> });
-
-makeShaped("of_nc_cobblestone_generator_mirrored",
-    <nuclearcraft:cobblestone_generator>,
-    ["AAA",
-     "C B",
-     "AAA"],
-    { A : <ore:plateSteel>,
-      B : <minecraft:water_bucket:*>,
-      C : <minecraft:lava_bucket:*> });
 
 //Crystal Growth Chamber
 recipes.addShaped(<ae2stuff:grower>, [


### PR DESCRIPTION
This PR allows the usage of any fluid container, such as GT cells and drums, or EIO portable tanks, or Thermal portable tanks, in crafting recipes involving buckets.

This is done through mass recipe replacing, replacing ingredients with a custom 'fluid bucket ingredient'. This ingredient also displays some options for containers in JEI, allowing for crafting auto-fill.

Some recipes have been changed:
- Cake + Cake Base + Chocolate Cake now supports dough or rice dough
- Cake + Cake Base no longer allow using unfilled buckets
- Concrete Bucket (for Firebricks Recipe) change:
	- Now makes Concrete Cell (Iron)
	- Takes a cell as input, and any fluid container (for water) as input
- New Recipe: Water + Lava = Obsidian

Reviewers:
- Anything else we should add to the display list? Should we remove something?
- Any recipes that are not replaced?
- Check for bugs involving crafting, e.g. crash, dupe, unexpected behaviours.