### PR TITLE
Hide EIO Lava Generator JEI Category

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -77,6 +77,7 @@ mods.jei.category.hideCategory('GrindingBall')
 mods.jei.category.hideCategory('SagMill')
 mods.jei.category.hideCategory('SolarPanel')
 mods.jei.category.hideCategory('StirlingGenerator')
+mods.jei.category.hideCategory('LavaGenerator')
 
 // AR
 mods.jei.category.hideCategory('zmaster587.AR.rollingMachine')


### PR DESCRIPTION
This PR simply hides the EIO Lava Generator JEI Category, which appears after `/gs reload` is performed.

Because it only appears after GroovyScript is reloaded, it does not affect normal gameplay.