### PR TITLE
Update Nomi Labs to 0.11.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5976827,
+      "fileID": 5981309,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -56,7 +56,8 @@ advanced {
      >
 
     # Whether to disable the Narrator.
-    # Fixes Crashes in Arm Macs, in some very specific environments.
+    # Fixes crashes in Arm Macs, in some development environments.
+    # This config does nothing outside of deobfuscated environments!
     # If your game is crashing, try enabling this!
     # [default: false]
     B:disableNarrator=false
@@ -461,6 +462,10 @@ content {
         # [default: false]
         B:enableBlocks=false
 
+        # Enable Custom GT Items.
+        # [default: true]
+        B:enableItems=true
+
         # Enable Custom Materials.
         # [default: true]
         B:enableMaterials=true
@@ -526,10 +531,10 @@ content {
 ##########################################################################################################
 
 "mod integration" {
-    # Whether to add a Empty Line between any Crafting Recipe Output Tooltips in JEI.
-    # Examples of Crafting Recipe Output Tooltips are `Recipe By <MOD_ID>` and `Recipe ID: <RECIPE_ID>`.
+    # Whether to add a Empty Line between any Ingredient Tooltips in JEI.
+    # Examples of Ingredient Tooltips are `Recipe By <MOD_ID>`, `Recipe ID: <RECIPE_ID>`, and `Accepts any: <ORE_DICT>`.
     # [default: true]
-    B:addJEICraftingOutputEmptyLine=true
+    B:addJEIIngEmptyLine=true
 
     # Whether to enable Advanced Rocketry Integration, which fixes Advanced Rocketry registering items for Fluid Blocks.
     # [default: true]


### PR DESCRIPTION
This PR simply updates Nomi Labs to 0.11.3, and updates the config.

Changes:
- Improved Cell Bucket Behaviour
- Fix DME Machine and JEI Gui Overlap