### PR TITLE
Add JEI Input Tooltip for Compressed Coke Clay

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5981309,
+      "fileID": 5992904,
       "required": true
     },
     {

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
@@ -3,10 +3,13 @@ import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilderCollection
 import com.nomiceu.nomilabs.groovy.RecipePredicates
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import gregtech.api.recipes.builders.SimpleRecipeBuilder
+import gregtech.client.utils.TooltipHelper
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fluids.FluidStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.addRecipeInputTooltip
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
 import static gregtech.api.GTValues.*
 
 if (LabsModeHelper.expert) {
@@ -30,6 +33,11 @@ if (LabsModeHelper.expert) {
 		.key('R', item('actuallyadditions:item_food', 16))
 		.key('M', ore('toolMortar'))
 		.register()
+
+	// Compressed Coke Clay Recipe
+	// Add Input Tooltip for Non-Consumed Wooden Form
+	addRecipeInputTooltip('gregtech:compressed_coke_clay', 4,
+		translatable("nomiceu.tooltip.mixed.not_consumed").addFormat(TooltipHelper.BLINKING_CYAN))
 } else {
 	// Remove mc paper recipe, is useless with endercore's shapeless one
 	crafting.remove('minecraft:paper')

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -8,6 +8,7 @@ nomiceu.tooltip.mixed.fillable=Can be filled with the §bCanning Machine§r.
 nomiceu.tooltip.mixed.mirrorable=§7Recipe can be mirrored.§r
 nomiceu.tooltip.mixed.accepts_fluid=§7Fluid: §b%s§r
 nomiceu.tooltip.mixed.accepts_fluid_container=§7Accepts §aBuckets§7, §aCells§7, §aDrums§7, and other §aFluid Containers§7!
+nomiceu.tooltip.mixed.not_consumed=Ingredient Not Consumed!
 
 # MC
 nomiceu.tooltip.mc.xp_bottle=§eGives 25 XP, or one XP Level!§r


### PR DESCRIPTION
This PR simply adds an input tooltip in JEI for the Compressed Coke Clay crafting recipe, stating that the Brick Wooden Form is not consumed.

This requires Labs update, as the update fixes an issue where GT Format Codes do not work in Translatables.