### PR TITLE
Fix Minor Text Issues in QB and Lang

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -11218,7 +11218,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
+          "desc:8": "§6RTM Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11230,7 +11230,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy",
+          "name:8": "RTM Alloy",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11426,7 +11426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer, §ca LV Extractor§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r. §cAn EV Chemical Reactor can also be used, if you want Tungsten Dust§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then §cextracted§r to get to §cTungsten Trioxide.\n\nThis can either be cooked in an EBF with Carbon to get Tungsten, or chemically reacted with Hydrogen to achieve Tungsten Dust.\n\nThe first option is recommended, as it saves Hydrogen, and takes less time to cook in the EBF than the latter option.§r",
+          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer§r, §ca LV Extractor§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r. §cAn EV Chemical Reactor can also be used, if you want Tungsten Dust§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then §cextracted§r to get to §cTungsten Trioxide.\n\nThis can either be cooked in an EBF with Carbon to get Tungsten, or chemically reacted with Hydrogen to achieve Tungsten Dust.\n\nThe first option is recommended, as it saves Hydrogen, and takes less time to cook in the EBF than the latter option.§r",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17739,7 +17739,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "§6RTM Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17751,7 +17751,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy Coil Blocks",
+          "name:8": "RTM Alloy Coil Blocks",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -43705,7 +43705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM-Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more. You will also need to process PGS for your initial yields of §6Iridium§r, as §6Osmiridium Ore§r and §6Iridosmine Ore§r are only available with the §6Tier Five Micro Miner§r. The mission also gives only small amounts, so processing PGS is the better option.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
+          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more. You will also need to process PGS for your initial yields of §6Iridium§r, as §6Osmiridium Ore§r and §6Iridosmine Ore§r are only available with the §6Tier Five Micro Miner§r. The mission also gives only small amounts, so processing PGS is the better option.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -13359,7 +13359,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
+          "desc:8": "§6RTM Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13371,7 +13371,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy",
+          "name:8": "RTM Alloy",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13606,7 +13606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer, §2Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
+          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer§r, §2Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21260,7 +21260,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "§6RTM Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21272,7 +21272,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy Coil Blocks",
+          "name:8": "RTM Alloy Coil Blocks",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -51117,7 +51117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM-Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
+          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -52995,7 +52995,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coming into §dLudicrous Voltage§r, many new advanced materials will be required to craft items and components. Most of these materials require §6RTM-Alloy Coils§r.\n\n§6Ruridit§r is an alloy of Ruthenium and Iridium. It is used in LuV components alongside §6HSS-S§r.\n\n§6Niobium-Titanium§r is the main LuV cable material. Later on, large quantities are required for §6Wetware Circuits§r.\n\n§6Vanadium-Gallium§r is the main ZPM cable material, but it is used now as an advanced conductive material for certain recipes.\n\n§6Osmiridium§r (not from the ore) is used to make the §6Ludicrous Voltage Coil§r, for LuV-tier energy I/O. It is later used to make ZPM components.\n\n§6Indium Tin Barium Titanium Cuprate§r is an LuV superconductor. Its uses are more limited, but it is used in places like the §3Fusion Reactor§r.\n\nFinally, §6Samarium§r is used for LuV+ motors. It is obtained from §6Rare Earth§r.\n\nThese materials take a long time at high temperatures to smelt, so find a way to keep a stock of them.",
+          "desc:8": "Coming into §dLudicrous Voltage§r, many new advanced materials will be required to craft items and components. Most of these materials require §6RTM Alloy Coils§r.\n\n§6Ruridit§r is an alloy of Ruthenium and Iridium. It is used in LuV components alongside §6HSS-S§r.\n\n§6Niobium-Titanium§r is the main LuV cable material. Later on, large quantities are required for §6Wetware Circuits§r.\n\n§6Vanadium-Gallium§r is the main ZPM cable material, but it is used now as an advanced conductive material for certain recipes.\n\n§6Osmiridium§r (not from the ore) is used to make the §6Ludicrous Voltage Coil§r, for LuV-tier energy I/O. It is later used to make ZPM components.\n\n§6Indium Tin Barium Titanium Cuprate§r is an LuV superconductor. Its uses are more limited, but it is used in places like the §3Fusion Reactor§r.\n\nFinally, §6Samarium§r is used for LuV+ motors. It is obtained from §6Rare Earth§r.\n\nThese materials take a long time at high temperatures to smelt, so find a way to keep a stock of them.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -13359,7 +13359,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
+          "desc:8": "§6RTM Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13371,7 +13371,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy",
+          "name:8": "RTM Alloy",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13606,7 +13606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer, §2Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
+          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer§r, §2Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21260,7 +21260,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "§6RTM Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21272,7 +21272,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy Coil Blocks",
+          "name:8": "RTM Alloy Coil Blocks",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -51117,7 +51117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM-Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
+          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -52995,7 +52995,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coming into §dLudicrous Voltage§r, many new advanced materials will be required to craft items and components. Most of these materials require §6RTM-Alloy Coils§r.\n\n§6Ruridit§r is an alloy of Ruthenium and Iridium. It is used in LuV components alongside §6HSS-S§r.\n\n§6Niobium-Titanium§r is the main LuV cable material. Later on, large quantities are required for §6Wetware Circuits§r.\n\n§6Vanadium-Gallium§r is the main ZPM cable material, but it is used now as an advanced conductive material for certain recipes.\n\n§6Osmiridium§r (not from the ore) is used to make the §6Ludicrous Voltage Coil§r, for LuV-tier energy I/O. It is later used to make ZPM components.\n\n§6Indium Tin Barium Titanium Cuprate§r is an LuV superconductor. Its uses are more limited, but it is used in places like the §3Fusion Reactor§r.\n\nFinally, §6Samarium§r is used for LuV+ motors. It is obtained from §6Rare Earth§r.\n\nThese materials take a long time at high temperatures to smelt, so find a way to keep a stock of them.",
+          "desc:8": "Coming into §dLudicrous Voltage§r, many new advanced materials will be required to craft items and components. Most of these materials require §6RTM Alloy Coils§r.\n\n§6Ruridit§r is an alloy of Ruthenium and Iridium. It is used in LuV components alongside §6HSS-S§r.\n\n§6Niobium-Titanium§r is the main LuV cable material. Later on, large quantities are required for §6Wetware Circuits§r.\n\n§6Vanadium-Gallium§r is the main ZPM cable material, but it is used now as an advanced conductive material for certain recipes.\n\n§6Osmiridium§r (not from the ore) is used to make the §6Ludicrous Voltage Coil§r, for LuV-tier energy I/O. It is later used to make ZPM components.\n\n§6Indium Tin Barium Titanium Cuprate§r is an LuV superconductor. Its uses are more limited, but it is used in places like the §3Fusion Reactor§r.\n\nFinally, §6Samarium§r is used for LuV+ motors. It is obtained from §6Rare Earth§r.\n\nThese materials take a long time at high temperatures to smelt, so find a way to keep a stock of them.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -11218,7 +11218,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
+          "desc:8": "§6RTM Alloy§r is an alloy of §6Ruthenium, Tungsten§r and §6Molybdenum§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11230,7 +11230,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy",
+          "name:8": "RTM Alloy",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11426,7 +11426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer, §ca LV Extractor§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r. §cAn EV Chemical Reactor can also be used, if you want Tungsten Dust§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then §cextracted§r to get to §cTungsten Trioxide.\n\nThis can either be cooked in an EBF with Carbon to get Tungsten, or chemically reacted with Hydrogen to achieve Tungsten Dust.\n\nThe first option is recommended, as it saves Hydrogen, and takes less time to cook in the EBF than the latter option.§r",
+          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer§r, §ca LV Extractor§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r. §cAn EV Chemical Reactor can also be used, if you want Tungsten Dust§r.\n\nIt is only found from §6Tungstate §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then §cextracted§r to get to §cTungsten Trioxide.\n\nThis can either be cooked in an EBF with Carbon to get Tungsten, or chemically reacted with Hydrogen to achieve Tungsten Dust.\n\nThe first option is recommended, as it saves Hydrogen, and takes less time to cook in the EBF than the latter option.§r",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17739,7 +17739,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6RTM-Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "§6RTM Alloy§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17751,7 +17751,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "RTM-Alloy Coil Blocks",
+          "name:8": "RTM Alloy Coil Blocks",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -43705,7 +43705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM-Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more. You will also need to process PGS for your initial yields of §6Iridium§r, as §6Osmiridium Ore§r and §6Iridosmine Ore§r are only available with the §6Tier Five Micro Miner§r. The mission also gives only small amounts, so processing PGS is the better option.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
+          "desc:8": "The §6Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum§r - are rare materials used in upcoming recipes. §6Ruthenium§r will be required now for the next tier of coils.\n\nThese materials can be obtained from ores exclusive to Microverse missions - §6Laurite Ore§r for Ruthenium, §6Cuprorhodsite Ore§r for Rhodium, and §6Osmiridium Ore§r and §6Iridosmine Ore§r for Osmium and Iridium. This should be enough for your initial needs, such as for §6RTM Alloy Coils§r, especially when using §6Tier Three Micro Miners§r.\n\nHowever, the yields of these ores from Microverse missions may not be enough in the long term, so you should consider processing §6Platinum Group Sludge (PGS)§r for more. You will also need to process PGS for your initial yields of §6Iridium§r, as §6Osmiridium Ore§r and §6Iridosmine Ore§r are only available with the §6Tier Five Micro Miner§r. The mission also gives only small amounts, so processing PGS is the better option.\n\nYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.\n\nIf you get stuck, check out the excellent flowcharts on the §eDiscord§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -36,7 +36,7 @@ nomiceu.tooltip.advancedrocketry.basic_lens=§7A basic lens, used for the Orbita
 
 # AE2 & NAE2
 nomiceu.tooltip.ae2.crafting_terminal_removal.1=§cThis item is being removed.§r
-nomiceu.tooltip.ae2.crafting_terminal_removal.2=§cA temperary conversion recipe has been added.§r
+nomiceu.tooltip.ae2.crafting_terminal_removal.2=§cA temporary conversion recipe has been added.§r
 nomiceu.tooltip.ae2.crafting_terminal_removal.3=§cCheck JEI for more details.§r
 nomiceu.tooltip.ae2.quantum_link_card.1=§eAllows wireless access from anywhere!§r
 nomiceu.tooltip.ae2.quantum_link_card.2=§eCheck the Quest Book for more information.§r


### PR DESCRIPTION
This PR:
- Renames RTM-Alloy to RTM Alloy in all parts of the Quest Book
- Fixes a missing resetting signal in Quest 201 (Tungsten)
- Fixes a typo (temperary) in lang