### PR TITLE
Update DME to v1.2.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -670,7 +670,7 @@
     },
     {
       "projectID": 737252,
-      "fileID": 5043404,
+      "fileID": 5985530,
       "required": true
     },
     {
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 5992904,
+      "fileID": 6015728,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates DeepMobEvolution to v1.2.3. This release integrates a fix that was previously in Labs, so Nomi Labs has also been updated (to v0.11.5).