### PR TITLE
Fix Tools Compat with Node 22

### DIFF
--- a/tools/buildConfig.ts
+++ b/tools/buildConfig.ts
@@ -1,3 +1,3 @@
-import buildConfig from "#utils/buildConfig.default.json" assert { type: "json" };
+import buildConfig from "#utils/buildConfig.default.json" with { type: "json" };
 
 export default buildConfig;

--- a/tools/globals.ts
+++ b/tools/globals.ts
@@ -1,6 +1,6 @@
 import buildConfig from "#buildConfig";
 import upath from "upath";
-import manifest from "./../manifest.json" assert { type: "json" };
+import manifest from "./../manifest.json" with { type: "json" };
 import { ModpackManifest } from "#types/modpackManifest.ts";
 
 export const sharedDestDirectory = upath.join(


### PR DESCRIPTION
This PR removes the usage of 'input assertions', which are removed in Node 22.

See [Stack Overflow Post](https://stackoverflow.com/questions/78876691/syntaxerror-unexpected-identifier-assert-on-json-import-in-node-v22).