### PR TITLE
Slightly Improve Flux Capacitor Tooltip

### DIFF
--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -92,7 +92,7 @@ nomiceu.tooltip.dme.matter=§eGives %s%% of a XP Level!§r
 nomiceu.tooltip.dme.matter.full_level=§eGives One XP Level!§r
 
 # Thermal Expansion
-nomiceu.tooltip.thermalexpansion.capacitors=§cCannot be discharged in GT Battery Buffers!§r
+nomiceu.tooltip.thermalexpansion.capacitors=§cCannot be discharged in GT Battery Buffers or Machines!§r
 
 # GregTech
 nomiceu.tooltip.gregtech.prospector.1=§6§lUsage:§r


### PR DESCRIPTION
This PR simply adds the notice that flux capacitors cannot be discharged by GT Machines as well as Battery Buffers to the tooltip.

This is in anticipation for some related quest book changes.