### PR TITLE
Fix Missing Basic Cell Crafting Recipe in HM

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -294,7 +294,7 @@ if (LabsModeHelper.expert) {
 		.key('E', ore('dustQuartzSand'))
 		.key('F', ore('dustClay'))
 		.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('water')))
-		.replace().register()
+		.register()
 
 	crafting.shapedBuilder()
 		.output(item('gregtech:metal_casing', 1))


### PR DESCRIPTION
This PR fixes all crafting recipes outputting an empty basic cell being removed in HM, due to a mistake in #1142.