### PR TITLE
Change Actually Additions' Laser Tool to GT Screwdriver

### DIFF
--- a/overrides/config/actuallyadditions.cfg
+++ b/overrides/config/actuallyadditions.cfg
@@ -108,7 +108,7 @@ other {
     # The non-Actually Additions items that are used to configure blocks from the mod. The first one is the Redstone Torch used to configure the Redstone Mode, and the second one is the Compass used to configure Laser Relays. If another mod overrides usage of either one of these items, you can change the registry name of the used items (using blocks is not possible) here.
     S:"Configuration Items" <
         minecraft:redstone_torch
-        minecraft:compass
+        gregtech:screwdriver
      >
 
     # The items that aren't allowed as outputs from OreDict Crusher recipes. Use this in case a mod, for example, adds a dust variant that can't be smelted into an ingot. Use REGISTRY NAMES, and if metadata is needed, add it like so: somemod:some_item@3

--- a/overrides/resources/gregtech/lang/en_us.lang
+++ b/overrides/resources/gregtech/lang/en_us.lang
@@ -1,2 +1,4 @@
 gregtech.material.rhodium_plated_palladium=Rhodium Plated Lumium-Palladium
 gregtech.machine.muffler_hatch.lv.name=Muffler Hatch
+
+item.gt.tool.screwdriver.name.name=Screwdriver


### PR DESCRIPTION
This PR is to change the tool used to configure Actually Additions' laser relays (switching I/O mode for Fluid relay and for Item relay, configure priority) from vanilla Compass to GregTech Screwdriver, so players don't have to carry an extra tool with them.

It contains a simple change to AA's config file and an extra line in `resources/gregtech/lang/en_us.lang` to prevent the tip text shown when looking at a laser while holding the Laser Wrench from showing the raw localization key `item.gt.tool.screwdriver.name.name`.

Tested and functioning as intended.