### PR TITLE
Change Labs' GT Recipe Search to Fast Discarded Tree

### DIFF
--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -520,7 +520,7 @@ content {
     # TREE
     # FAST_DISCARDED_TREE
     # DISCARDED_TREE
-    S:gtRecipeSearchMode=LINEAR_SEARCH
+    S:gtRecipeSearchMode=FAST_DISCARDED_TREE
 }
 
 
@@ -714,5 +714,3 @@ content {
     }
 
 }
-
-


### PR DESCRIPTION
This PR changes the recipe search algorithm used in GT Search by Output to use Fast Discarded Tree.

This means, instead of looping through all recipes, removing follows a tree-like structure, which is updated for every recipe addition/removal. This has only been enabled now due to a large usage of these methods in our Groovy Scripts, as this also introduces overhead during game loading.

The tree is discarded on game load, to prevent memory overhead during play. However, developers may wish to set it to Fast Tree (not discarded) for their development instances, which keeps it during play, allowing for fast groovy script reloading times (around ~500ms - ~1000ms reduction in script reload, excluding JEI reload).

Testing showed that this does lead to a decrease in game loading time (50s -> 48s).