### PR TITLE
Update Build Pack Lang Job Name

### DIFF
--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -357,7 +357,7 @@ jobs:
           compression-level: 9
 
   buildLang:
-    name: Build Pack Lang and Changelogs (${{ inputs.tag }})
+    name: Build Pack Lang (${{ inputs.tag }})
     runs-on: ubuntu-latest
     if: ${{ inputs.separate_upload }}
     needs: makeNames


### PR DESCRIPTION
This PR simply changes the Build Pack Lang job to reflect the fact that it no longer builds, or uploads, the changelog, as of #1023.