### PR TITLE
Update Had Enough Items to 4.26.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -610,7 +610,7 @@
     },
     {
       "projectID": 557549,
-      "fileID": 5726160,
+      "fileID": 5906628,
       "required": true
     },
     {

--- a/overrides/config/jei/jei.cfg
+++ b/overrides/config/jei/jei.cfg
@@ -22,7 +22,7 @@ advanced {
     # Choose if HEI should give ingredients direct to the inventory (inventory) or pick them up with the mouse (mouse_pickup).
     # [Default: mouse_pickup]
     # [Valid: [inventory, mouse_pickup]]
-    S:giveMode=MOUSE_PICKUP
+    S:giveMode=mouse_pickup
 
     # The maximum width of the ingredient list. [range: 4 ~ 100, default: 100]
     I:maxColumns=100


### PR DESCRIPTION
This PR updates Had Enough Items to v4.26.2, which fixes issues with FluidStack NBTs and improves optifine support. Impact on gameplay is minimal.