### PR TITLE
Update Nomi Labs to 0.12.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6041387,
+      "fileID": 6045158,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6045158,
+      "fileID": 6045696,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -583,6 +583,13 @@ content {
     # [default: true]
     B:enableTopAddonsIntegration=true
 
+    # Whether to make the Actually Additions Laser Relays take all GT Screwdrivers as the configuration tool.
+    # Note that compasses will still work if this config is true! Change the Actually Additions config to change that behaviour!
+    # Changing it to gregtech:screwdriver instead of minecraft:compass is recommended.
+    # You wil also have to add a lang key for the tooltip.
+    # [default: false]
+    B:gtScrewdriveAARelays=true
+
     ##########################################################################################################
     # draconic evolution integration
     #--------------------------------------------------------------------------------------------------------#

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Mid-Game/midgame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Mid-Game/midgame.groovy
@@ -1,3 +1,5 @@
+import com.nomiceu.nomilabs.util.LabsModeHelper
+
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
 
@@ -22,3 +24,12 @@ mods.gregtech.centrifuge.recipeBuilder()
 
 // Nether Star Block -> Nether Star
 crafting.addShapeless(item('minecraft:nether_star') * 9, [ore('blockNetherStar')])
+
+// Nitrogen -> Liquid Nitrogen
+if (LabsModeHelper.expert) {
+	mods.gregtech.vacuum_freezer.recipeBuilder()
+		.fluidInputs(fluid('nitrogen') * 1000)
+		.fluidOutputs(fluid('liquid_nitrogen') * 1000)
+		.duration(90).EUt(VA[HV])
+		.buildAndRegister()
+}

--- a/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/Mod-Specific/jei.groovy
@@ -27,6 +27,10 @@ if (LabsModeHelper.expert) {
 	mods.jei.ingredient.hide(item('nomilabs:impossiblerealmdata'))
 }
 
+if (LabsModeHelper.normal) {
+	mods.jei.ingredient.hide(fluid('liquid_nitrogen'))
+}
+
 // GregTech
 // Higher Tier Muffler Hatches
 for (var tier : [MV, HV, EV, IV, LuV, ZPM, UV]) {


### PR DESCRIPTION
This PR updates Nomi Labs to v0.12.2, which adds Liquid Nitrogen.

0.12.3 adds:
- New internal alternatives to GS reload for different use cases
- Allows Electric LV Screwdriver in configuring AA lasers