### PR TITLE
Actually Additions: Label Tool as GregTech

### DIFF
--- a/overrides/resources/gregtech/lang/en_us.lang
+++ b/overrides/resources/gregtech/lang/en_us.lang
@@ -1,4 +1,4 @@
 gregtech.material.rhodium_plated_palladium=Rhodium Plated Lumium-Palladium
 gregtech.machine.muffler_hatch.lv.name=Muffler Hatch
 
-item.gt.tool.screwdriver.name.name=Screwdriver
+item.gt.tool.screwdriver.name.name=GregTech Screwdriver


### PR DESCRIPTION
This PR labels the directional tool as from GregTech, to avoid confusion from players.