### PR TITLE
Misc The One Probe Improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6045696,
+      "fileID": 6051550,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -742,3 +742,24 @@ content {
 }
 
 
+##########################################################################################################
+# top settings
+#--------------------------------------------------------------------------------------------------------#
+# The One Probe Settings
+##########################################################################################################
+
+"top settings" {
+    # Enable Display of GT Recipe Outputs in TOP.
+    # [default: true]
+    B:enableGTRecipeOutput=true
+
+    # Mode to enable Labs' RF Provider. Behaviour is the same as TOP's, but allows for rearranging the RF bar.
+    # You will have to set TOP's 'RF Mode' to 0.
+    # 0: Disable, 1: Show as Bar, 2: Show as Text
+    # [default: 0]
+    # Min: 0
+    # Max: 2
+    I:rfProviderMode=1
+}
+
+

--- a/overrides/config/theoneprobe.cfg
+++ b/overrides/config/theoneprobe.cfg
@@ -51,6 +51,8 @@ client {
 
     # 0 means don't show break progress, 1 is show as bar, 2 is show as text [range: 0 ~ 2, default: 1]
     I:showBreakProgress=1
+
+    # If true show liquid information when the probe hits liquid first [default: false]
     B:showLiquids=true
 
     # Text style. Use a comma delimited list with colors like: 'red', 'green', 'blue', ... or style codes like 'underline', 'bold', 'italic', 'strikethrough', ... [default: red,bold]
@@ -103,22 +105,55 @@ providers {
     S:excludedProviders <
      >
 
-    # Order in which entity providers should be used [default: [theoneprobe:entity.default], [theoneprobe:entity.debug], [theoneprobe:entity.entity]]
+    # Order in which entity providers should be used [default: [theoneprobe:entity.default], [theoneprobe:entity.debug], [theoneprobe:entity.entity], [topaddons:base], [topaddons:architecturecraft], [topaddons:chisel], [topaddons:extrautils2], [topaddons:storagedrawers], [topaddons:thermalexpansion], [topaddons:vanilla]]
     S:sortedEntityProviders <
         theoneprobe:entity.default
         theoneprobe:entity.debug
         theoneprobe:entity.entity
      >
 
-    # Order in which providers should be used [default: [theoneprobe:default], [theoneprobe:debug], [theoneprobe:block], [gregtech:energy_container_provider], [gregtech:workable_provider], [thermalexpansion.topplugin], [enderio:default], [simplefluidtanks:TankInfoProvider]]
+    # Order in which providers should be used [default: [theoneprobe:default], [theoneprobe:debug], [theoneprobe:block], [nomilabs:steam_machine_provider], [nomilabs:recipe_outputs], [nomilabs:top_tooltips], [nomilabs:rf_provider], [ae2stuff:InfoProvider], [gregtech:energy_container_provider], [gregtech:workable_provider], [gregtech:controllable_provider], [gregtech:transformer_info_provider], [gregtech:diode_info_provider], [gregtech:multiblock_controller_provider], [gregtech:multiblock_maintenance_provider], [gregtech:multi_recipemap_provider], [gregtech:converter_info_provider], [gregtech:recipe_logic_provider], [gregtech:steam_boiler_provider], [gregtech:primitive_pump_provider], [gregtech:coverable_provider], [gregtech:ore_block_provider], [gregtech:lamp_info_provider], [gregtech:ld_pipe_provider], [gregtech:laser_container_provider], [gregtech:debug_pipe_net_provider], [gregtech:debug_tick_time_provider], [appliedenergistics2:TileInfoProvider], [appliedenergistics2:PartInfoProvider], [thermalexpansion.topplugin], [enderio:default], [dimensionaledibles:cake], [topaddons:base], [topaddons:architecturecraft], [topaddons:chisel], [topaddons:extrautils2], [topaddons:storagedrawers], [topaddons:thermalexpansion], [topaddons:vanilla], [supersoundmuffler:default]]
     S:sortedProviders <
         theoneprobe:default
         theoneprobe:debug
         theoneprobe:block
-        gregtech:energy_container_provider
+        topaddons:base
+        nomilabs:recipe_outputs
+        ae2stuff:InfoProvider
         gregtech:workable_provider
+        gregtech:controllable_provider
+        gregtech:transformer_info_provider
+        gregtech:diode_info_provider
+        gregtech:multiblock_controller_provider
+        gregtech:multiblock_maintenance_provider
+        gregtech:multi_recipemap_provider
+        gregtech:converter_info_provider
+        gregtech:recipe_logic_provider
+        gregtech:steam_boiler_provider
+        gregtech:primitive_pump_provider
+        gregtech:coverable_provider
+        gregtech:ore_block_provider
+        gregtech:lamp_info_provider
+        gregtech:ld_pipe_provider
+        gregtech:laser_container_provider
+        gregtech:debug_pipe_net_provider
+        gregtech:debug_tick_time_provider
         thermalexpansion.topplugin
         enderio:default
+        dimensionaledibles:cake
+        topaddons:architecturecraft
+        topaddons:chisel
+        topaddons:extrautils2
+        topaddons:storagedrawers
+        topaddons:vanilla
+        supersoundmuffler:default
+        appliedenergistics2:TileInfoProvider
+        appliedenergistics2:PartInfoProvider
+        nomilabs:steam_machine_provider
+        nomilabs:top_tooltips
+        nomilabs:rf_provider
+        topaddons:thermalexpansion
+        gregtech:energy_container_provider
      >
 }
 
@@ -231,7 +266,7 @@ theoneprobe {
     I:showModName=1
 
     # How to display RF: 0 = do not show, 1 = show in a bar, 2 = show as text [range: 0 ~ 2, default: 1]
-    I:showRF=1
+    I:showRF=0
 
     # Show redstone (0 = not, 1 = always, 2 = sneak) [range: 0 ~ 2, default: 1]
     I:showRedstone=1

--- a/overrides/config/topaddons_client.cfg
+++ b/overrides/config/topaddons_client.cfg
@@ -7,7 +7,7 @@
     B:colorDragonName=true
 
     # Which tank gauge(s) to display (The One Probe, TOP Addons, Both). [default: Both]
-    S:fluidGaugeDisplay=Both
+    S:fluidGaugeDisplay=TOP Addons
 
     # Only show Forestry machines' important failure reasons when crouching. [default: false]
     B:forestryReasonCrouch=false


### PR DESCRIPTION
This PR makes many improvements to The One Probe:
- Improved Display of Fluids
  - Removed Duplicate Textual Display
  - Improved Compactness and Readability
- Added Display of GT Machine Recipe Outputs
  - Originally from GregicProbeCEu, but changes were made:
    - Improved Compactness
    - Merging of Item and Fluid Outputs into One Display
    - Removed Display for Generators
    - Fixed Fluid Localization
- Improved Ordering
  - Consistent Grouping of Items and Fluid Information
  - Moves Energy Information to Bottom 