### PR TITLE
Disable NuclearCraft Fission Reactor Meltdowns

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6051550,
+      "fileID": 6065951,
       "required": true
     },
     {

--- a/overrides/config/nuclearcraft.cfg
+++ b/overrides/config/nuclearcraft.cfg
@@ -181,7 +181,7 @@ fission {
     B:fission_water_cooler_requirement=true
 
     # Can fission reactors overheat?
-    B:fission_overheat=true
+    B:fission_overheat=false
 
     # Will fission reactors explode when they overheat?
     B:fission_explosions=false


### PR DESCRIPTION
This PR disables NC meltdowns.

Because the default config simply causes the reactor to forever gain heat, therefore making cooling useless, Labs must also be updated. The new Labs release simply makes NC reactors behave appropriately when meltdowns are disabled.