### PR TITLE
Update Nomi Labs to 0.12.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6065951,
+      "fileID": 6069413,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -499,6 +499,19 @@ content {
 ##########################################################################################################
 
 "groovyscript settings" {
+    # Mode to Use for Crafting Output Cache.
+    # DISABLED keeps the default behaviour of searching through all Crafting Recipes.
+    # DISCARDED or SAVED caches outputs of recipes. This cache is used when removing/replacing by output, with an ItemStack.
+    # This causes two changes in behaviour: Output Removing/Replacing no longer removes GroovyScript added recipes, and Output Removing/Replacing only matches based on item and meta, ignoring NBT.
+    # If the NBT tag is desired to be matched, a non-ItemStack IIngredient should be used for output searching.
+    # DISCARDED discards the cache after script loading, saving memory during gameplay. SAVED keeps the cache during gameplay, removing the need to rebuild the cache for reloading.
+    # [default: DISABLED]
+    # Valid values:
+    # DISABLED
+    # DISCARDED
+    # SAVED
+    S:craftingOutputCacheMode=DISCARDED
+
     # Whether to enable Labs' GroovyScript Hand Additions.
     # [default: false]
     B:enableGroovyHandAdditions=false

--- a/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Misc/fluidCrafting.groovy
@@ -73,8 +73,7 @@ crafting.shapelessBuilder()
 crafting.shapelessBuilder()
 	.output(item('littletiles:lttransparentcoloredblock', 5) * 2)
 	.input(fluidIng(fluid('water')), fluidIng(fluid('water')))
-	.setInputTooltip(0, IngredientFluidBucket.getInputTooltip(fluid('water')))
-	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
+	.setInputTooltip(IngredientFluidBucket.getInputTooltip(fluid('water')))
 	.replace().register()
 
 // Waterstone
@@ -160,7 +159,7 @@ if (LabsModeHelper.expert) {
 crafting.shapelessBuilder()
 	.output(item('littletiles:ltcoloredblock', 12))
 	.input(fluidIng(fluid('lava')))
-	.setInputTooltip(4, IngredientFluidBucket.getInputTooltip(fluid('lava')))
+	.setInputTooltip(IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.replace().register()
 
 // Lavastone


### PR DESCRIPTION
This PR updates Nomi Labs to v0.12.7, which adds:
- Crafting Recipe Output Caching, improving script load speeds by ~100-200ms, whilst only costing ~10ms
- Cleaner Recipe Input and Output Tooltip Setting
- APIs for overriding JEI Recipe Catalyst Display (What can be used to Perform Recipe)