### PR TITLE
Cleanup Crafting Tables

### DIFF
--- a/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
+++ b/overrides/groovy/postInit/Post-Initial/Main/General/Early-Game/earlygame.groovy
@@ -9,8 +9,27 @@ import net.minecraftforge.fluids.FluidStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.addRecipeInputTooltip
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
 import static gregtech.api.GTValues.*
+
+// Change Recipe for AA's Crafting Table on a Stick to be Stick + Table
+crafting.replaceShapeless(item('actuallyadditions:item_crafter_on_a_stick'),
+	[item('minecraft:stick'), item('minecraft:crafting_table')])
+
+// Deprecate Extended Crafting's Handheld Crafting Table
+mods.jei.ingredient.removeAndHide(item('extendedcrafting:handheld_table'))
+
+addTooltip(item('extendedcrafting:handheld_table'), translatable('nomiceu.tooltip.mixed.deprecated'))
+
+crafting.shapelessBuilder()
+	.output(item('actuallyadditions:item_crafter_on_a_stick'))
+	.input(item('extendedcrafting:handheld_table'))
+	.setOutputTooltip(translatable('nomiceu.tooltip.mixed.deprecation'))
+	.register()
+
+// Remove Avaritia Double Compressed -> Compressed Crafting Table Recipe (Double Compressed is Unobtainable and Removed)
+crafting.remove('avaritia:blocks/crafting/un_double_compressed_crafting_table')
 
 if (LabsModeHelper.expert) {
 	// Log -> Stick Shortcut (Expert Mode)

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -9,6 +9,8 @@ nomiceu.tooltip.mixed.mirrorable=§7Recipe can be mirrored.§r
 nomiceu.tooltip.mixed.accepts_fluid=§7Fluid: §b%s§r
 nomiceu.tooltip.mixed.accepts_fluid_container=§7Accepts §aBuckets§7, §aCells§7, §aDrums§7, and other §aFluid Containers§7!
 nomiceu.tooltip.mixed.not_consumed=Ingredient Not Consumed!
+nomiceu.tooltip.mixed.deprecated=§cItem Deprecated! Place in Crafting Grid to Convert!§r
+nomiceu.tooltip.mixed.deprecation=§cConversion Recipe from Deprecated Item to Alternative!§r
 
 # MC
 nomiceu.tooltip.mc.xp_bottle=§eGives 25 XP, or one XP Level!§r


### PR DESCRIPTION
This PR cleans up crafting tables:
- Deprecates Extended Crafting's Handheld Crafting Table
  - Replaces AA's Crafting Table on a Stick's Recipe to be Stick + Crafting Table
  - Adds a Conversion Recipe from Handheld Crafting Table to Crafting Table on a Stick
- Removes Recipe from Avaritia's Double Compressed Crafting Table to Compressed Crafting Table