### PR TITLE
Fix AE2 Blocking Config

### DIFF
--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -40,7 +40,7 @@ blockingmode {
     # NonBlockingItems
     S:nonBlockingItems <
         [gregtech]
-        gregtech:meta_item_1:461
+        gregtech:circuit.integrated
         gregtech:shape.mold.plate
         gregtech:shape.mold.gear
         gregtech:shape.mold.credit
@@ -67,21 +67,13 @@ blockingmode {
         gregtech:shape.extruder.pipe.large
         gregtech:shape.extruder.pipe.huge
         gregtech:shape.extruder.block
-        gregtech:shape.extruder.sword
-        gregtech:shape.extruder.pickaxe
-        gregtech:shape.extruder.shovel
-        gregtech:shape.extruder.axe
-        gregtech:shape.extruder.hoe
-        gregtech:shape.extruder.hammer
-        gregtech:shape.extruder.file
-        gregtech:shape.extruder.saw
         gregtech:shape.extruder.gear
         gregtech:shape.extruder.bottle
         gregtech:shape.extruder.foil
         gregtech:shape.extruder.gear_small
         gregtech:shape.extruder.rod_long
         gregtech:shape.extruder.rotor
-        gregtech:glass_lens.white
+        gregtech:lensGlass
         gregtech:glass_lens.orange
         gregtech:glass_lens.magenta
         gregtech:glass_lens.light_blue
@@ -97,9 +89,7 @@ blockingmode {
         gregtech:glass_lens.green
         gregtech:glass_lens.red
         gregtech:glass_lens.black
-        nomilabs:smallgearextrudershape
         nomilabs:creativeportabletankmold
-
         [ae2stuff]
         appliedenergistics2:material:13
         appliedenergistics2:material:14


### PR DESCRIPTION
This PR fixes errors in the AE2 Blocking Config, relating to:
- Small Gear Mold from Craft Tweaker / Nomi Labs not existing
- Extruder Shapes for Tool Heads not existing
- Glass Lens being specified incorrectly
- Programmed Circuit being parsed incorrectly