### PR TITLE
Improve Deprecation Tooltips and Conversion Recipes

### DIFF
--- a/overrides/groovy/postInit/main/general/earlyGame/earlygame.groovy
+++ b/overrides/groovy/postInit/main/general/earlyGame/earlygame.groovy
@@ -11,24 +11,12 @@ import net.minecraftforge.fluids.FluidStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.addRecipeInputTooltip
-import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
 import static gregtech.api.GTValues.*
 
 // Change Recipe for AA's Crafting Table on a Stick to be Stick + Table
 crafting.replaceShapeless(item('actuallyadditions:item_crafter_on_a_stick'),
 	[item('minecraft:stick'), item('minecraft:crafting_table')])
-
-// Deprecate Extended Crafting's Handheld Crafting Table
-mods.jei.ingredient.removeAndHide(item('extendedcrafting:handheld_table'))
-
-addTooltip(item('extendedcrafting:handheld_table'), translatable('nomiceu.tooltip.mixed.deprecated'))
-
-crafting.shapelessBuilder()
-	.output(item('actuallyadditions:item_crafter_on_a_stick'))
-	.input(item('extendedcrafting:handheld_table'))
-	.setOutputTooltip(translatable('nomiceu.tooltip.mixed.deprecation'))
-	.register()
 
 // Remove Avaritia Double Compressed -> Compressed Crafting Table Recipe (Double Compressed is Unobtainable and Removed)
 crafting.remove('avaritia:blocks/crafting/un_double_compressed_crafting_table')

--- a/overrides/groovy/postInit/main/general/misc/deprecation.groovy
+++ b/overrides/groovy/postInit/main/general/misc/deprecation.groovy
@@ -1,0 +1,138 @@
+package postInit.main.general.misc
+
+import com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials
+import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
+import gregtech.api.recipes.RecipeBuilder
+import gregtech.api.recipes.category.RecipeCategories
+import gregtech.api.recipes.ingredients.GTRecipeOreInput
+import gregtech.api.unification.OreDictUnifier
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fluids.FluidStack
+
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.addTooltip
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.MaterialHelpers.forMaterial
+import static gregtech.api.recipes.RecipeMaps.*
+
+var deprecated = translatable('nomiceu.tooltip.mixed.deprecated')
+var deprecation = translatable('nomiceu.tooltip.mixed.deprecation')
+
+var deprecate = { ItemStack stack ->
+	mods.jei.ingredient.removeAndHide(stack)
+	addTooltip(stack, deprecated)
+}
+
+var conversion = { ItemStack old, ItemStack curr ->
+	crafting.shapelessBuilder()
+		.output(curr)
+		.input(old)
+		.setOutputTooltip(deprecation)
+		.register()
+}
+
+// Deprecate Old Wireless Crafting Terminal and Upgrades
+mods.jei.ingredient.removeAndHide(item('wct:magnet_card'))
+conversion(item('wct:magnet_card'), item('appliedenergistics2:material', 60))
+
+mods.jei.ingredient.removeAndHide(item('ae2wtlib:infinity_booster_card'))
+conversion(item('ae2wtlib:infinity_booster_card'), item('appliedenergistics2:material', 59))
+
+mods.jei.ingredient.removeAndHide(item('wct:wct'))
+conversion(item('wct:wct'), item('appliedenergistics2:material', 58))
+
+// Old Wireless Terminal Tooltips
+for (var stack : [item('ae2wtlib:infinity_booster_card'), item('wct:wct'), item('wct:magnet_card')]) {
+	addTooltip(stack, [
+		translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.1'),
+		translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.2'),
+		translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.3'),
+	])
+}
+
+// Hide Creative Wireless Terminal
+mods.jei.ingredient.hide(item('wct:wct_creative'))
+
+// Deprecate Extended Crafting's Handheld Crafting Table
+deprecate(item('extendedcrafting:handheld_table'))
+conversion(item('extendedcrafting:handheld_table'), item('actuallyadditions:item_crafter_on_a_stick'))
+
+// Conversion from Thermal Saltpeter and Obsidian to GT Versions
+// Removal is still handled by OreDict.zs for now, but we can move it over later
+addTooltip(item('thermalfoundation:material', 770), deprecated)
+conversion(item('thermalfoundation:material', 770), metaitem('dustObsidian'))
+
+addTooltip(item('thermalfoundation:material', 772), deprecated)
+conversion(item('thermalfoundation:material', 772), metaitem('dustSaltpeter'))
+
+// Conversion from Draconic Evolution's Draconium Dust, Block of Draconium and Block of Awakened Draconium
+// Removal is still handled by OreDict.zs for now, but we can move it over later
+addTooltip(item('draconicevolution:draconium_dust'), deprecated)
+conversion(item('draconicevolution:draconium_dust'), metaitem('nomilabs:dustDraconium'))
+
+addTooltip(item('draconicevolution:draconium_block'), deprecated)
+conversion(item('draconicevolution:draconium_block'), metaitem('nomilabs:blockDraconium'))
+
+addTooltip(item('draconicevolution:draconic_block'), deprecated)
+conversion(item('draconicevolution:draconic_block'), metaitem('nomilabs:blockAwakenedDraconium'))
+
+// Deprecate GT Mithril and GT Infinity
+for (var mat : [LabsMaterials.Mithril, LabsMaterials.Infinity]) {
+	forMaterial(mat, { ItemStack stack -> deprecate(stack)},
+		{ FluidStack fluid ->
+			mods.jei.ingredient.removeAndHide(fluid)
+		}, false)
+}
+
+// Mana Infused Conversion Recipes
+conversion(metaitem('nomilabs:ingotMithril'), item('thermalfoundation:material', 136))
+conversion(metaitem('nomilabs:plateMithril'), item('thermalfoundation:material', 72))
+
+// Infinity Conversion Recipes
+conversion(metaitem('nomilabs:ingotInfinity'), item('avaritia:resource', 6))
+conversion(metaitem('nomilabs:plateInfinity'), item('moreplates:infinity_plate'))
+
+/* Replace Infinity GT Machine Recipes */
+
+// Remove Ingot -> Nugget Recipe
+mods.gregtech.alloy_smelter.removeByOutput([metaitem('nomilabs:nuggetInfinity')], null)
+
+// Recipes for Ingot
+furnace.removeByOutput(metaitem('nomilabs:ingotInfinity'))
+furnace.add(metaitem('nomilabs:dustInfinity'), item('avaritia:resource', 6))
+
+// Arc Furnace: special, we set category, and fix block & plate inputs
+mods.gregtech.arc_furnace.changeByOutput([metaitem('nomilabs:ingotInfinity')], null)
+	.forEach { ChangeRecipeBuilder builder ->
+		builder.builder { RecipeBuilder recipe ->
+			recipe.category(RecipeCategories.ARC_FURNACE_RECYCLING)
+		}.changeEachInput{
+			return new GTRecipeOreInput(OreDictUnifier.getOreDictionaryNames(it.inputStacks[0]).first())
+		}.changeEachOutput { item('avaritia:resource', 6) * it.count }
+		.replaceAndRegister()
+	}
+
+for (var map : [COMPRESSOR_RECIPES, ALLOY_SMELTER_RECIPES]) {
+	map.getVirtualized().changeByOutput([metaitem('nomilabs:ingotInfinity')], null)
+		.forEach { ChangeRecipeBuilder builder ->
+			builder.changeEachOutput { item('avaritia:resource', 6) * it.count }
+			.replaceAndRegister()
+		}
+}
+
+// Recipes for Block
+for (var map : [COMPRESSOR_RECIPES, ALLOY_SMELTER_RECIPES, EXTRUDER_RECIPES]) {
+	map.getVirtualized().changeByOutput([metaitem('nomilabs:blockInfinity')], null)
+		.forEach { ChangeRecipeBuilder builder ->
+			builder.changeEachOutput { item('avaritia:block_resource', 1) * it.count }
+				.replaceAndRegister()
+		}
+}
+
+// Recipes for Plate
+for (var map : [FORGE_HAMMER_RECIPES, CUTTER_RECIPES, EXTRUDER_RECIPES, BENDER_RECIPES]) {
+	map.getVirtualized().changeByOutput([metaitem('nomilabs:plateInfinity')], null)
+		.forEach { ChangeRecipeBuilder builder ->
+			builder.changeEachOutput { item('moreplates:infinity_plate') * it.count }
+				.replaceAndRegister()
+		}
+}

--- a/overrides/groovy/postInit/main/general/misc/tooltips.groovy
+++ b/overrides/groovy/postInit/main/general/misc/tooltips.groovy
@@ -95,15 +95,6 @@ addTooltip(item('advancedrocketry:lens'), translatable('nomiceu.tooltip.advanced
 
 /* AE2 & NAE2 */
 
-// AE2 Wireless Crafting Terminal (Old Deprecated Items)
-for (ItemStack deprecated : [item('ae2wtlib:infinity_booster_card'), item('wct:wct'), item('wct:magnet_card')]) {
-	addTooltip(deprecated, [
-	    translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.1'),
-		translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.2'),
-		translatable('nomiceu.tooltip.ae2.crafting_terminal_removal.3'),
-	])
-}
-
 // Quantum Link Card
 addTooltip(item('appliedenergistics2:material', 59), [
     translatable('nomiceu.tooltip.ae2.quantum_link_card.1'),

--- a/overrides/groovy/postInit/main/modSpecific/ae2/misc.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/ae2/misc.groovy
@@ -8,20 +8,6 @@ import static gregtech.api.GTValues.*
 // Standardise fluix dust
 ore('dustFluix').add(item('appliedenergistics2:material', 8))
 
-// Conversion Recipes (DEPRECATED)
-crafting.shapelessBuilder()
-	.output(item('appliedenergistics2:material', 59))
-	.input(item('ae2wtlib:infinity_booster_card'))
-	.register()
-crafting.shapelessBuilder()
-	.output(item('appliedenergistics2:wireless_crafting_terminal'))
-	.input(item('wct:wct'))
-	.register()
-crafting.shapelessBuilder()
-	.output(item('appliedenergistics2:material', 60))
-	.input(item('wct:magnet_card'))
-	.register()
-
 // JEI
 mods.jei.ingredient.removeAndHide(item('appliedenergistics2:material', 0))
 

--- a/overrides/groovy/postInit/main/modeSpecific/normal/removeMaterials.groovy
+++ b/overrides/groovy/postInit/main/modeSpecific/normal/removeMaterials.groovy
@@ -1,0 +1,106 @@
+package postInit.main.modeSpecific.normal
+
+import com.nomiceu.nomilabs.util.LabsModeHelper
+import gregtech.api.unification.material.Material
+
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.MaterialHelpers.removeAndHideMaterial
+import static com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials.*
+
+// Normal Mode Specific (Hiding Hard Mode Materials)
+if (!LabsModeHelper.isNormal()) return
+
+Material[] materials = [
+	// Elemental Materials
+	Taranium,
+	// Chemical Materials
+	TungstenTrioxide,
+	BerylliumOxide,
+	NiobiumPentoxide,
+	TantalumPentoxide,
+	ManganeseDifluoride,
+	MolybdenumTrioxide,
+	LeadChloride,
+	Wollastonite,
+	SodiumMetavanadate,
+	VanadiumPentoxide,
+	AmmoniumMetavanadate,
+	PhthalicAnhydride,
+	Ethylanthraquinone,
+	HydrogenPeroxide,
+	Hydrazine,
+	AcetoneAzine,
+	GrapheneOxide,
+	Durene,
+	PyromelliticDianhydride,
+	Dimethylformamide,
+	Aminophenol,
+	Oxydianiline,
+	AntimonyPentafluoride,
+	LeadMetasilicate,
+	Butanol,
+	PhosphorusTrichloride,
+	PhosphorylChloride,
+	TributylPhosphate,
+	// Naq Line Materials
+	NaquadahOxide,
+	Pyromorphite,
+	NaquadahHydroxide,
+	CaesiumHydroxide,
+	Neocryolite,
+	NaquadahOxidePetroSolution,
+	NaquadahOxideAeroSolution,
+	HotNaquadahOxideNeocryoliteSolution,
+	// Taranium Line Materials
+	HexafluorosilicicAcid,
+	DirtyHexafluorosilicicAcid,
+	StoneResidue,
+	UncommonResidue,
+	OxidisedResidue,
+	RefinedResidue,
+	CleanInertResidue,
+	UltraacidicResidue,
+	XenicAcid,
+	DustyHelium,
+	TaraniumEnrichedHelium,
+	TaraniumDepletedHelium,
+	TritiumHydride,
+	HeliumHydride,
+	DioxygenDifluoride,
+	// Platinum Line Materials
+	PlatinumMetallic,
+	PalladiumMetallic,
+	AmmoniumHexachloroplatinate,
+	ChloroplatinicAcid,
+	PotassiumBisulfate,
+	PotassiumPyrosulfate,
+	PotassiumSulfate,
+	ZincSulfate,
+	SodiumNitrate,
+	RhodiumNitrate,
+	SodiumRuthenate,
+	SodiumPeroxide,
+	IridiumDioxideResidue,
+	AmmoniumHexachloroiridiate,
+	PlatinumGroupResidue,
+	PalladiumRichAmmonia,
+	CrudePlatinumResidue,
+	CrudePalladiumResidue,
+	IridiumGroupSludge,
+	RhodiumSulfateSolution,
+	CrudeRhodiumResidue,
+	RhodiumSalt,
+	AcidicIridiumDioxideSolution,
+	PlatinumPalladiumLeachate,
+	MethylFormate,
+	FormicAcid,
+	SodiumMethoxide,
+	// Microverse Materials
+	Snowchestite,
+	Dulysite,
+	// Endgame Materials
+	KaptonK
+]
+
+for (def material : materials) {
+	removeAndHideMaterial(material, false)
+}

--- a/overrides/scripts/DraconicEvolution.zs
+++ b/overrides/scripts/DraconicEvolution.zs
@@ -127,23 +127,9 @@ assembly_line.recipeBuilder()
 	.property("research", <draconicevolution:wyvern_energy_core>)
 	.duration(1200).EUt(30720).buildAndRegister();
 
-
-recipes.addShapeless(<metaitem:nomilabs:dustDraconium>, [<draconicevolution:draconium_dust>]);
-
-// Hacky fix for broken DE stuff
-//<ore:ingotDraconiumAwakened>.add(<metaitem:nomilabs:ingotAwakenedDraconium>);
-
-<draconicevolution:draconic_ingot>.displayName = "Activated Awakened Draconium Ingot";
-<draconicevolution:draconium_block>.displayName = "Activated Draconium Block";
-<draconicevolution:draconic_block>.displayName = "Activated Awakened Draconium Block";
-
 recipes.removeByRecipeName("draconicevolution:draconic_ingot_1");
 recipes.removeByRecipeName("draconicevolution:draconium_ingot_1");
 recipes.removeByRecipeName("draconicevolution:draconium_block");
-
-// Conversion Recipes
-recipes.addShapeless(<metaitem:nomilabs:blockDraconium>, [<draconicevolution:draconium_block>]);
-recipes.addShapeless(<metaitem:nomilabs:blockAwakenedDraconium>, [<draconicevolution:draconic_block>]);
 
 /*
 chemical_bath.recipeBuilder()

--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -339,22 +339,14 @@ mixer.recipeBuilder()
     .inputs([<thermalfoundation:material:1028>, <metaitem:dustTitanium>])
     .duration(200).EUt(30).buildAndRegister();
 
-// Change drops of pulverised obsidian and niter, add (temporary) conversion recipes
+// Change drops of pulverised obsidian and niter
 val basalzEntity = <entity:thermalfoundation:basalz>;
 basalzEntity.removeDrop(<thermalfoundation:material:770>);
 basalzEntity.addPlayerOnlyDrop(<metaitem:dustObsidian> % 80, 0, 2); // 80% is around the rate observed.
 
-recipes.addShapeless(<metaitem:dustObsidian>, [<thermalfoundation:material:770>]);
-
 val blitzEntity = <entity:thermalfoundation:blitz>;
 blitzEntity.removeDrop(<thermalfoundation:material:772>);
 blitzEntity.addPlayerOnlyDrop(<metaitem:dustSaltpeter> % 80, 0, 2); // 80% is around the rate observed.
-
-recipes.addShapeless(<metaitem:dustSaltpeter>, [<thermalfoundation:material:772>]);
-
-// Temporary Conversion recipe between gt and thermal mana infused
-recipes.addShapeless(<thermalfoundation:material:136>, [<metaitem:nomilabs:ingotMithril>]);
-recipes.addShapeless(<thermalfoundation:material:72>, [<metaitem:nomilabs:dustMithril>]);
 
 // Hide GT Mana infused (Moved to Groovy)
 

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1919,12 +1919,6 @@ mods.jei.JEI.removeAndHide(<extrautils2:book>);
 mods.jei.JEI.removeAndHide(<extrautils2:minichest>);
 mods.jei.JEI.removeAndHide(<extrautils2:analogcrafter>);
 
-// Wireless Terminals Removals
-mods.jei.JEI.removeAndHide(<ae2wtlib:infinity_booster_card>);
-mods.jei.JEI.removeAndHide(<wct:wct>);
-mods.jei.JEI.removeAndHide(<wct:wct_creative>);
-mods.jei.JEI.removeAndHide(<wct:magnet_card>);
-
 //Gregtech Removals
 mods.jei.JEI.removeAndHide(<metaitem:world_accelerator.lv>);
 mods.jei.JEI.removeAndHide(<metaitem:world_accelerator.mv>);


### PR DESCRIPTION
This PR improves deprecations by:
- Moving all deprecations to one script
- Adding tooltips to all deprecated items
- Adding an Output Tooltip to deprecation conversion recipes

This PR also fixes certain operations with Infinity Ingots/Blocks on GT Machines producing GT Infinity.

Note that the lang keys used for deprecation tooltips were originally added in https://github.com/Nomi-CEu/Nomi-CEu/pull/1194.