### PR TITLE
Fix AR Orbital Laser Drill Not Being Buildable

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
@@ -15,6 +15,31 @@ mods.enderio.enchanter.recipeBuilder()
 	.xpCostMultiplier(3) // 27 Levels, 15 Lapis
 	.register()
 
+// Lens Block
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('gregtech:transparent_casing', 1) * 3,
+		item('advancedrocketry:lens') * 3,
+		ore('stickLongRuridit')
+	)
+	.outputs(item('advancedrocketry:blocklens'))
+	.duration(100).EUt(VA[LuV])
+	.buildAndRegister()
+
+// Vacuum-Chamber High Power Laser Emitter
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('advancedrocketry:blocklens'),
+		ore('gemPerfectRuby'),
+		ore('plateTitaniumTungstenCarbide') * 4,
+		item('gregtech:laser_pipe_normal') * 8,
+		metaitem('electric.pump.luv'),
+		item('libvulpes:structuremachine')
+	).fluidInputs(fluid('polytetrafluoroethylene') * 1296)
+	.outputs(item('advancedrocketry:vacuumlaser'))
+	.duration(280).EUt(VA[LuV])
+	.buildAndRegister()
+
 // Recipes for Industrial Rebreather Kit
 int airtightId = Enchantment.getEnchantmentID(enchantment('advancedrocketry:spacebreathing'))
 ItemStack airtight = item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) airtightId, 'lvl': (short) 1]]])

--- a/overrides/resources/advancedrocketry/lang/en_us.lang
+++ b/overrides/resources/advancedrocketry/lang/en_us.lang
@@ -3,3 +3,5 @@ tile.fuelStation.name=Fueling Station
 
 # line 131 of jar file
 item.lens.0.name=Orbital Laser Drill Lens
+
+tile.lens.name=Orbital Laser Drill Lens Block

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1534,7 +1534,6 @@ mods.jei.JEI.removeAndHide(<advancedrocketry:liquidtank>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:intake>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:solargenerator>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:railgun>);
-mods.jei.JEI.removeAndHide(<advancedrocketry:blocklens>);
 //mods.jei.JEI.removeAndHide(<advancedrocketry:forcefieldprojector>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:spaceelevatorcontroller>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:beacon>);


### PR DESCRIPTION
Title.
This PR contains recipes for Lens (block) and Vacuum-Chamber High Power Laser Emitter, both are required to build a OLD multiblock.

Also renames the Lens to Orbital Laser Drill Lens Block to fit the renamed Orbital Laser Drill Lens. It's actually kinda lame but I couldn't think of a better name, further edit is welcomed.