### PR TITLE
Revert "Fix AR Orbital Laser Drill Not Being Buildable (#1207)"

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
@@ -15,31 +15,6 @@ mods.enderio.enchanter.recipeBuilder()
 	.xpCostMultiplier(3) // 27 Levels, 15 Lapis
 	.register()
 
-// Lens Block
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		item('gregtech:transparent_casing', 1) * 3,
-		item('advancedrocketry:lens') * 3,
-		ore('stickLongRuridit')
-	)
-	.outputs(item('advancedrocketry:blocklens'))
-	.duration(100).EUt(VA[LuV])
-	.buildAndRegister()
-
-// Vacuum-Chamber High Power Laser Emitter
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		item('advancedrocketry:blocklens'),
-		ore('gemPerfectRuby'),
-		ore('plateTitaniumTungstenCarbide') * 4,
-		item('gregtech:laser_pipe_normal') * 8,
-		metaitem('electric.pump.luv'),
-		item('libvulpes:structuremachine')
-	).fluidInputs(fluid('polytetrafluoroethylene') * 1296)
-	.outputs(item('advancedrocketry:vacuumlaser'))
-	.duration(280).EUt(VA[LuV])
-	.buildAndRegister()
-
 // Recipes for Industrial Rebreather Kit
 int airtightId = Enchantment.getEnchantmentID(enchantment('advancedrocketry:spacebreathing'))
 ItemStack airtight = item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) airtightId, 'lvl': (short) 1]]])

--- a/overrides/resources/advancedrocketry/lang/en_us.lang
+++ b/overrides/resources/advancedrocketry/lang/en_us.lang
@@ -3,5 +3,3 @@ tile.fuelStation.name=Fueling Station
 
 # line 131 of jar file
 item.lens.0.name=Orbital Laser Drill Lens
-
-tile.lens.name=Orbital Laser Drill Lens Block

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1534,6 +1534,7 @@ mods.jei.JEI.removeAndHide(<advancedrocketry:liquidtank>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:intake>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:solargenerator>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:railgun>);
+mods.jei.JEI.removeAndHide(<advancedrocketry:blocklens>);
 //mods.jei.JEI.removeAndHide(<advancedrocketry:forcefieldprojector>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:spaceelevatorcontroller>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:beacon>);


### PR DESCRIPTION
This reverts commit 83d9e6147c1892756eda2a3d92287ea041f05c6d.

I totally forgot the fact that I'm using AR 2.x on my end. The OLD is actually buildable without the need of Vacuum-Chamber High Power Laser Emitter (it does not even exist in AR 1.x) nor the Lens Block (used in Observatory, which is disable and has no use in Nomi), so the whole PR is not actually needed.

Terribly sorry for any possible chaos.