### PR TITLE
Fix fluidCrafting.groovy replacing shapeless cable recipes

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
@@ -42,7 +42,7 @@ for (var entry : [0: 'glass', 20: 'covered', 40: 'smart', 60: 'dense_smart', 500
 		.output(output)
 		.input(cables, fluidIng(fluid('water')))
 		.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('water')))
-		.replace().register()
+		.register()
 }
 
 // Paper


### PR DESCRIPTION
We're already removing the recipe using ``crafting.remove``. ``.replace()`` is removing the shapeless recipes for cable_dense_covered, cable_smart, and cable_dense_smart. 