### PR TITLE
Fix Missing Torch Recipes

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
@@ -274,14 +274,15 @@ crafting.shapedBuilder()
 	.replace().register()
 
 // Torch
+crafting.remove('gregtech:torch_creosote')
 crafting.shapedBuilder()
 	.output(item('minecraft:torch') * 16)
 	.matrix('AB', 'C ')
 	.key('A', ore('wool'))
 	.key('B', fluidIng(fluid('creosote')))
-	.key('C', ore('stick'))
+	.key('C', ore('stickWood'))
 	.setInputTooltip(1, IngredientFluidBucket.getInputTooltip(fluid('creosote')))
-	.replace().register()
+	.register()
 
 // Concrete Cell + Firebricks
 if (LabsModeHelper.expert) {

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -5,7 +5,7 @@ import mods.gregtech.material.Material;
 import crafttweaker.data.IData;
 import mods.actuallyadditions.AtomicReconstructor;
 
-recipes.remove(<thermalexpansion:satchel:2>);
+recipes.removeByRecipeName("thermalexpansion:satchel_3");
 recipes.addShaped("test", <thermalexpansion:satchel:2>, [
 	[null, <metaitem:nuggetElectrum>, null],
 	[<metaitem:ingotAluminium>, <thermalexpansion:satchel:1>.marked("satchel"), <metaitem:ingotAluminium>], 


### PR DESCRIPTION
This PR fixes torch recipes, that don't use the wool and bucket of creosote, being missing.

This PR also fixes the torch recipe with wool and bucket of creosote missing sticks.

Fixes #1212