### PR TITLE
Fix Occasional XP Disappearances when Dim Changing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -593,6 +593,11 @@
       "required": true
     },
     {
+      "projectID": 486778,
+      "fileID": 3372374,
+      "required": true
+    },
+    {
       "projectID": 490698,
       "fileID": 3337685,
       "required": true


### PR DESCRIPTION
This PR fixes xp sometimes disappearing when changing dimensions.

Whilst this bug has been mostly fixed by Universal Tweaks, there have been reports that this can still sometimes occur, but adding this mod prevents all occurances.