### PR TITLE
Small JEI Tweaks

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/jei.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/jei.groovy
@@ -44,6 +44,11 @@ for (var tier : [MV, HV, EV, IV, LuV, ZPM, UV]) {
 	mods.jei.ingredient.removeAndHide(MetaTileEntities.MUFFLER_HATCH[tier].getStackForm())
 }
 
+// Extended Crafting
+// Ender & Enhanced Ender
+mods.jei.ingredient.hide(item('extendedcrafting:storage', 5)) // Block of Ender
+mods.jei.ingredient.hide(item('extendedcrafting:material', 49)) // Enhanced Ender Nugget
+
 // Better Questing
 List<ItemStack> lootBoxes = [
 	item('bq_standard:loot_chest'),
@@ -121,7 +126,8 @@ overrideRecipeCatalysts('minecraft.crafting',
 	item('actuallyadditions:item_crafter_on_a_stick'),
 	item('extrautils2:crafter'),
 	item('enderio:block_crafter'),
-	item('enderio:block_inventory_panel'))
+	item('enderio:block_inventory_panel'),
+	item('appliedenergistics2:molecular_assembler'))
 
 // Smelting (add More Furnaces' Furnaces)
 List<Object> furnaceCatalysts = [item('minecraft:furnace')]

--- a/overrides/groovy/postInit/main/modSpecific/jei.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/jei.groovy
@@ -124,10 +124,10 @@ overrideRecipeCatalysts('minecraft.crafting',
 	item('avaritia:compressed_crafting_table'),
 	metaitem('workbench'),
 	item('actuallyadditions:item_crafter_on_a_stick'),
+	item('appliedenergistics2:molecular_assembler'),
 	item('extrautils2:crafter'),
 	item('enderio:block_crafter'),
-	item('enderio:block_inventory_panel'),
-	item('appliedenergistics2:molecular_assembler'))
+	item('enderio:block_inventory_panel'))
 
 // Smelting (add More Furnaces' Furnaces)
 List<Object> furnaceCatalysts = [item('minecraft:furnace')]


### PR DESCRIPTION
This PR makes two small JEI tweaks:
- Hides unused Extended Crafting's Ender and Enhanced Ender
- Adds AE2's Molecular Assembler to crafting table catalyst