### PR TITLE
Fix Main Menu Presence Using Wrong Logo

### DIFF
--- a/overrides/config/craftpresence.json
+++ b/overrides/config/craftpresence.json
@@ -167,6 +167,7 @@
   "statusMessages": {
     "mainMenuData": {
       "textOverride": "In the Main Menu",
+      "iconOverride": "{custom.logo_slug}",
       "data": {
         "enabled": true,
         "useAsMain": false,


### PR DESCRIPTION
This PR fixes main menu's rich presence not using the mod-specific logo.