### PR TITLE
Update Inventory Bogo Sorter to v1.4.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -650,7 +650,7 @@
     },
     {
       "projectID": 632327,
-      "fileID": 5162169,
+      "fileID": 5650806,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Bogosort to 1.4.9, required after updating Nomi Labs to v0.13.0.