### PR TITLE
Remove EnderIO's 'Old' Glowstone Nano Particles

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/eio.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/eio.groovy
@@ -1,5 +1,6 @@
 package postInit.main.modSpecific
 
+import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
 import net.minecraft.item.ItemStack
 import classes.postInit.Common
 
@@ -18,3 +19,12 @@ crafting.shapedBuilder()
 	.key('B', ore('itemConduitBinder'))
 	.key('P', item('appliedenergistics2:part', 36))
 	.replace().register()
+
+// Replace the 'old' Glowstone nano particles with the 'not old' one
+// Not really serving any purpose, but removing the need for two items that do the same thing
+mods.jei.ingredient.hide(item('enderio:block_holy_fog'))
+mods.gregtech.macerator.changeByOutput([item('enderio:block_holy_fog')], null)
+	.forEach { ChangeRecipeBuilder b ->
+		b.changeEachOutput {item('enderio:block_holier_fog') }
+			.replaceAndRegister()
+	}


### PR DESCRIPTION
This PR replaces the recipe to create the 'old' glowstone nano particles, and instead makes it produce the 'not old' one, and hides the 'old' one from JEI.