### PR TITLE
Fix Little Tiles Lava and Container Clearing Conflict

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
@@ -159,7 +159,7 @@ if (LabsModeHelper.expert) {
 
 // Little Tiles Lava
 crafting.shapelessBuilder()
-	.output(item('littletiles:ltcoloredblock', 12))
+	.output(item('littletiles:ltcoloredblock', 12) * 2)
 	.input(fluidIng(fluid('lava')), fluidIng(fluid('lava')))
 	.setInputTooltip(IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.replace().register()

--- a/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
@@ -160,7 +160,7 @@ if (LabsModeHelper.expert) {
 // Little Tiles Lava
 crafting.shapelessBuilder()
 	.output(item('littletiles:ltcoloredblock', 12))
-	.input(fluidIng(fluid('lava')))
+	.input(fluidIng(fluid('lava')), fluidIng(fluid('lava')))
 	.setInputTooltip(IngredientFluidBucket.getInputTooltip(fluid('lava')))
 	.replace().register()
 


### PR DESCRIPTION
This PR fixes the Little Tiles Lava Crafting Recipe and container clearing shapeless recipes conflicting.