### PR TITLE
Fix Changelogs in CI Build Packs

### DIFF
--- a/.github/workflows/testbuildpack.yml
+++ b/.github/workflows/testbuildpack.yml
@@ -33,4 +33,5 @@ jobs:
       head_ref: ${{ github.head_ref }}
       true_sha: ${{ github.event.pull_request.head.sha }}
       skip_changelog: ${{ github.event.pull_request != null }}
+      release_type: Cutting Edge Build
     secrets: inherit


### PR DESCRIPTION
This PR fixes changelogs in CI Built Packs not having the correct formatting in the title, reporting the changelog as 'Release Head' instead of 'Cutting Edge Build <Timestamp>'.