### PR TITLE
Update Nomi Labs to v0.14.0, Update AE2 to v0.56.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -620,7 +620,7 @@
     },
     {
       "projectID": 570458,
-      "fileID": 5378163,
+      "fileID": 5411078,
       "required": true
     },
     {
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6142200,
+      "fileID": 6286857,
       "required": true
     },
     {

--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -125,6 +125,10 @@ advanced {
     # NOMI
     S:languageModifyOption=NOMI
 
+    # Whether mode check fail message should link to the Nomi-CEu GitHub page.
+    # [default: false]
+    B:modeCheckNomiCeuLink=true
+
     # Amount of XP Per Level, for Linear XP Scaling.
     # Used for Linear XP Scaling in Actually Additions, EIO and Thermal Items/Machines.
     # Note that for Thermal, XP fixes are only applied for the Tome of Knowledge, not for any machines associated with Essence of Knowledge.
@@ -166,6 +170,10 @@ advanced {
     # [default: ]
     S:serverSideMethods <
      >
+
+    # Name of server when displaying welcome messages. Only applies to Dedicated Servers.
+    # [default: Minecraft]
+    S:serverWelcomeName=Nomi-CEu
 
     ##########################################################################################################
     # fluid registry
@@ -552,6 +560,17 @@ content {
     # [default: true]
     B:addJEIIngEmptyLine=true
 
+    # Make Prospector default to Dark Mode.
+    # Improves visibility of light ores, and dark ores are still visible.
+    # Coal Ore has visibility problems if this option is turned on, but it is the only ore, compared to many light ores.
+    # Note that while light/dark mode is togglable in terminal, it is not with the item.
+    # [default: true]
+    B:defaultDarkMode=true
+
+    # Whether to disable drops of Armor Plus Fragments from the Ender Dragon, Wither and Elder Guardian.
+    # [default: false]
+    B:disableArmorPlusFragDrops=true
+
     # Whether to enable Advanced Rocketry Integration, which fixes Advanced Rocketry registering items for Fluid Blocks.
     # [default: true]
     B:enableAdvancedRocketryIntegration=true
@@ -569,6 +588,12 @@ content {
     # Whether to enable Default World Generator Port Integration, which fixes scaling issues, and adds a cancel button.
     # [default: true]
     B:enableDefaultWorldGenIntegration=true
+
+    # Enable Dummy Muffler hatches.
+    # Makes muffler hatches not produce ash anymore.
+    # This improves performance when multiblocks try to calculate ash output. This is especially useful for high parallels.
+    # [default: false]
+    B:enableDummyMufflers=true
 
     # Whether to enable Ender IO Integration, which adds a tooltip beneath capacitors displaying their level.
     # [default: true]
@@ -811,5 +836,3 @@ content {
     # Max: 2
     I:rfProviderMode=1
 }
-
-


### PR DESCRIPTION
This PR updates Labs to v0.14.0, and AE2 to v0.56.6, and updates the configs for Labs.

In this release:
- **Embeds in BQu Descriptions**
- **Mode Validation Between Server/Client**
- **Dummy Muffler Hatches**, improves performance with high parallel multiblocks
- Prospector: Shows Y-Level, shows dilithium/black quartz
- Ore Drill: Accepts ME Output Hatches, can mine dilithium/black quartz
- Server welcome message, message to clarify server has started
- AE2 Update Support (with patches)
- Allow NAE2 Upgrade Cards in AE2FC interfaces
- Remove Armor Plus Fragment Drops
- TOP Output Display Fixes & Improvements
- Cache phantomface validation server-side, fixes issues with (hud display of) it and storage exposer