### PR TITLE
Add Maceration Recipe for Black Quartz Ore

### DIFF
--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -60,3 +60,18 @@ mods.gregtech.macerator.changeByInput([item('gregtech:stone_smooth', 1)], null)
 	.changeEachChancedOutput { ChancedItemOutput output ->
 		return chanced(output.ingredient, 100, 100) // Original: 0.1%, + 0.05%, New: 1%, +1%
 	}.replaceAndRegister()
+
+// Maceration of Dilithium and Black Quartz Ore
+// Critical to ensure they work in ore drills (multiblock)
+mods.gregtech.macerator.recipeBuilder()
+	.inputs(ore('oreDilithium'))
+	.outputs(item('libvulpes:productdust') * 2)
+	.duration(200).EUt(VA[HV])
+	.buildAndRegister();
+
+mods.gregtech.macerator.recipeBuilder()
+	.inputs(ore('oreQuartzBlack'))
+	.outputs(item('actuallyadditions:item_dust', 7) * 2)
+	.duration(200).EUt(VA[HV])
+	.buildAndRegister();
+

--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -544,14 +544,6 @@ makeShaped("ar_fueling_station",
 		M: <ore:pipeNormalFluidStainlessSteel>,    // Medium Stainless Steel Pipe
 	});
 
-// Dilithium Dust
-macerator.recipeBuilder()
-	.inputs([<libvulpes:ore0>])
-	.outputs([<ore:dustDilithium>.firstItem * 2])
-	.duration(200)
-	.EUt(420)
-	.buildAndRegister();
-
 // Dilithium Crystal
 autoclave.recipeBuilder()
 	.inputs([<ore:dustDilithium> * 4])


### PR DESCRIPTION
This PR adds a macerator recipe for Black Quartz Ore.

This:
- Improves consistency with other ores
- Allows multiblock Ore Drills to output items when mining Black Quartz Ore (after the fix in #1242)