### PR TITLE
Fix Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - New processing chains for Naquadah, Advanced SMDs, Crystal Chips, and more
 - Fixed lots of unpleasant CE-ness - fixed infinite Amp bug, different ore stone types don't clog up your inventory, etc.
 - Super-performant emissive effects on machines, coil blocks, the Fusion Reactor, and more
-- Assembly Line Research, Cleanrooom, and other ported and improved features from GT5
+- Assembly Line Research, Cleanroom, and other ported and improved features from GT5
 - Updated questbook to guide you through all the new stuff, including a completely new chapter, the Processing Lines Tab, to give you more info, useful tips and a visual representation of different processing lines, both new and old
 - Many QoL features - Wiremill can produce any wire, Creative Tank no longer uses fluids, new creative chests and tanks from CEu, etc.
 - And more...

--- a/overrides/README.md
+++ b/overrides/README.md
@@ -1,4 +1,4 @@
-# Expert Mode Instalation
+# Expert Mode Installation
 Config Changes for Normal and Expert Mode are found in `/config-overrides/normal` and `/config-overrides/expert` respectively.
 
 Users can use any of the below methods to replace configs:


### PR DESCRIPTION
This PR simply fixes two typos: `Cleanrooom` instead of `Cleanroom` and `Instalation` instead of `Installation`.