### PR TITLE
Allow NuclearCraft Active Coolers to Permeate Fluids

### DIFF
--- a/overrides/config/nuclearcraft.cfg
+++ b/overrides/config/nuclearcraft.cfg
@@ -1207,7 +1207,7 @@ processors {
     B:smart_processor_input=true
 
     # Will passive machines such as Active Coolers and Electromagnets spread their items, fluid and energy to adjacent passive machines?
-    B:passive_permeation=false
+    B:passive_permeation=true
 
     # Will machines produce particle effects while running?
     B:processor_particles=true


### PR DESCRIPTION
Fixes #1248.
Very simple config change following what was said in the related issue