### PR TITLE
Update Nomi Labs to v0.14.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6331064,
+      "fileID": 6333765,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Labs to v0.14.3, improving the previously added drawer content tooltips.