### PR TITLE
Add Typo Checking CI Tasks

### DIFF
--- a/.github/workflows/buildpack.yml
+++ b/.github/workflows/buildpack.yml
@@ -30,11 +30,11 @@ on:
         required: false
         type: string
       compare_tag:
-        description: Tag(s) to compare against. If specifying multiple, seperate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
+        description: Tag(s) to compare against. If specifying multiple, separate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
         required: false
         type: string
       separate_upload:
-        description: Whether to upload each zip (Client, Server, Lang) and the changelogs seperately. If not set, will just upload all six files into one artifact (Built Pack).
+        description: Whether to upload each zip (Client, Server, Lang) and the changelogs separately. If not set, will just upload all six files into one artifact (Built Pack).
         required: true
         type: boolean
       skip_changelog:
@@ -71,7 +71,7 @@ on:
         required: false
         type: string
       separate_upload:
-        description: Whether to upload each zip (Client, Server & Lang) and the changelogs seperately. If not set, will just upload all five files into one artifact (Built Pack).
+        description: Whether to upload each zip (Client, Server & Lang) and the changelogs separately. If not set, will just upload all five files into one artifact (Built Pack).
         required: false
         default: false
         type: boolean

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout Ref
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Restore NPM Cached Files
         uses: actions/cache@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,3 +41,17 @@ jobs:
       - name: Check QB
         working-directory: ./tools
         run: npm run gulp checkQB
+
+      - name: Build Lang Typo Check
+        working-directory: ./tools
+        run: npm run gulp buildTypoCheck
+
+      - name: Lang Typo Check
+        uses: crate-ci/typos@v1
+        with:
+          files: build/typo-check/
+
+      - name: GitHub Workflow and Templates Typo Check
+        uses: crate-ci/typos@v1
+        with:
+          files: .github/

--- a/.github/workflows/createchangelog.yml
+++ b/.github/workflows/createchangelog.yml
@@ -17,7 +17,7 @@ on:
           - 'Alpha Release'
           - 'Cutting Edge Build'
       compare_tag:
-        description: Tag(s) to compare against. If not set, will use the tag before `Tag`. If specifying multiple, seperate by commas. (Spaces allowed).
+        description: Tag(s) to compare against. If not set, will use the tag before `Tag`. If specifying multiple, separate by commas. (Spaces allowed).
         required: false
       branch:
         description: Branch to push changelog to. If not set, changelog will just be uploaded as an artifact.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ on:
         required: false
         type: string
       compare_tag:
-        description: Tag(s) to compare against. If specifying multiple, seperate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
+        description: Tag(s) to compare against. If specifying multiple, separate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
         required: false
         type: string
       deploy_to_gh:
@@ -75,4 +75,3 @@ jobs:
       tag: ${{ inputs.tag }}
       release_type: ${{ inputs.release_type }}
     secrets: inherit
-

--- a/.github/workflows/releasechangelog.yml
+++ b/.github/workflows/releasechangelog.yml
@@ -16,7 +16,7 @@ on:
           - 'Beta Release'
           - 'Alpha Release'
       compare_tag:
-        description: Tag(s) to compare against. If not set, will use the tag before `Tag`. If specifying multiple, seperate by commas. (Spaces allowed).
+        description: Tag(s) to compare against. If not set, will use the tag before `Tag`. If specifying multiple, separate by commas. (Spaces allowed).
         required: false
       branch:
         description: Branch to push changelog to. If not set, changelog will just be uploaded as an artifact.
@@ -30,7 +30,7 @@ jobs:
       tag: ${{ inputs.tag }}
       release_type: ${{ inputs.release_type }}
     secrets: inherit
-    
+
   createChangelog:
     name: Create Changelog (${{ inputs.tag }})
     needs: releaseCommit

--- a/.github/workflows/releasedeploy.yml
+++ b/.github/workflows/releasedeploy.yml
@@ -17,7 +17,7 @@ on:
           - 'Beta Release'
           - 'Alpha Release'
       compare_tag:
-        description: Tag(s) to compare against. If specifying multiple, seperate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
+        description: Tag(s) to compare against. If specifying multiple, separate by commas. (Spaces allowed). See CONTRIBUTING.md for more information.
         required: false
         type: string
       deploy_to_gh:
@@ -39,7 +39,7 @@ jobs:
       tag: ${{ inputs.tag }}
       release_type: ${{ inputs.release_type }}
     secrets: inherit
-    
+
   build:
     name: Build Pack (${{ inputs.tag }})
     needs: releaseCommit

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -59244,7 +59244,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oThis quest completes via checkbox or upon achieving Silicon Dioxide Dust.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeperate your §6Glass Dust§r into §6Silicon Dioxide Dust§r. Can be electrolyzed into useful resources.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
+          "desc:8": "§oThis quest completes via checkbox or upon achieving Silicon Dioxide Dust.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeparate your §6Glass Dust§r into §6Silicon Dioxide Dust§r. Can be electrolyzed into useful resources.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -59358,7 +59358,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oThis quest completes via checkbox or upon achieving Sand.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeperate your §6Quartz Sand§r into §6Quartzite Dust§r and §6Certus Quartz Dust§r. This is a good renewable source of §6Certus Quartz§r, which you need for §bApplied Energistics 2§r.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
+          "desc:8": "§oThis quest completes via checkbox or upon achieving Sand.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeparate your §6Quartz Sand§r into §6Quartzite Dust§r and §6Certus Quartz Dust§r. This is a good renewable source of §6Certus Quartz§r, which you need for §bApplied Energistics 2§r.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -59244,7 +59244,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oThis quest completes via checkbox or upon achieving Silicon Dioxide Dust.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeperate your §6Glass Dust§r into §6Silicon Dioxide Dust§r. Can be electrolyzed into useful resources.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
+          "desc:8": "§oThis quest completes via checkbox or upon achieving Silicon Dioxide Dust.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeparate your §6Glass Dust§r into §6Silicon Dioxide Dust§r. Can be electrolyzed into useful resources.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -59358,7 +59358,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oThis quest completes via checkbox or upon achieving Sand.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeperate your §6Quartz Sand§r into §6Quartzite Dust§r and §6Certus Quartz Dust§r. This is a good renewable source of §6Certus Quartz§r, which you need for §bApplied Energistics 2§r.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
+          "desc:8": "§oThis quest completes via checkbox or upon achieving Sand.\n\nThis step requires a Centrifuge at voltage §lLV §oor higher.§r\n\nSeparate your §6Quartz Sand§r into §6Quartzite Dust§r and §6Certus Quartz Dust§r. This is a good renewable source of §6Certus Quartz§r, which you need for §bApplied Energistics 2§r.\n\n\n\nYou might have noticed that all quests in this line complete automatically via the main resource achieved by that step. This is as this §eCobbleworks§r chain is extremely versatile, and each resource may be important or not, depending on your situation.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/tools/globals.ts
+++ b/tools/globals.ts
@@ -27,6 +27,10 @@ export const langDestDirectory = upath.join(
 	buildConfig.buildDestinationDirectory,
 	"lang",
 );
+export const typoCheckDirectory = upath.join(
+	buildConfig.buildDestinationDirectory,
+	"typo-check",
+);
 export const tempDirectory = upath.join(
 	buildConfig.buildDestinationDirectory,
 	"temp",

--- a/tools/gulpfile.ts
+++ b/tools/gulpfile.ts
@@ -17,7 +17,7 @@ export const createChangelog = changelog.createRootChangelog;
 import * as sharedTasks from "./tasks/shared/index.ts";
 import clientTasks from "./tasks/client/index.ts";
 import serverTasks from "./tasks/server/index.ts";
-import langTasks from "./tasks/lang/index.ts";
+import * as langTasks from "./tasks/lang/index.ts";
 import mmcTasks from "./tasks/mmc/index.ts";
 import * as modTasks from "./tasks/misc/downloadMods.ts";
 
@@ -26,7 +26,7 @@ export const buildServer = gulp.series(
 	gulp.parallel(sharedTasks.default, modTasks.downloadSharedAndServer),
 	serverTasks,
 );
-export const buildLang = gulp.series(sharedTasks.default, langTasks);
+export const buildLang = gulp.series(sharedTasks.default, langTasks.default);
 export const buildMMC = gulp.series(
 	gulp.parallel(sharedTasks.default, modTasks.downloadSharedAndClient),
 	mmcTasks,
@@ -35,7 +35,7 @@ export const buildAll = gulp.series(
 	sharedTasks.default,
 	gulp.parallel(
 		clientTasks,
-		langTasks,
+		langTasks.default,
 		gulp.series(modTasks.downloadSharedAndServer, serverTasks),
 	),
 );
@@ -43,8 +43,8 @@ export const buildChangelog = sharedTasks.buildChangelog;
 
 import { extractTypoCheckFiles } from "#tasks/helpers/langExtract.ts";
 export const buildTypoCheck = gulp.series(
-	sharedTasks.fastTypoBuild,
-	langTasks,
+	sharedTasks.typoBuild,
+	langTasks.typoBuild,
 	extractTypoCheckFiles,
 );
 

--- a/tools/gulpfile.ts
+++ b/tools/gulpfile.ts
@@ -41,6 +41,13 @@ export const buildAll = gulp.series(
 );
 export const buildChangelog = sharedTasks.buildChangelog;
 
+import { extractTypoCheckFiles } from "#tasks/helpers/langExtract.ts";
+export const buildTypoCheck = gulp.series(
+	sharedTasks.fastTypoBuild,
+	langTasks,
+	extractTypoCheckFiles,
+);
+
 import checkTasks from "./tasks/checks/index.ts";
 export const check = gulp.series(checkTasks);
 

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -31,6 +31,7 @@
 				"@types/unzipper": "^0.10.9",
 				"@typescript-eslint/eslint-plugin": "^7.8.0",
 				"@typescript-eslint/parser": "^7.8.0",
+				"async-folder-walker": "^3.0.5",
 				"axios": "^1.6.8",
 				"axios-retry": "^4.1.0",
 				"case-switcher-js": "^1.1.10",
@@ -560,13 +561,13 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+			"version": "10.1.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
+			"integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.0.0",
+				"@octokit/types": "^13.6.2",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -589,19 +590,20 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
-			"integrity": "sha512-o4WRoOJZlKqEEgj+i9CpcmnByvtzoUYC6I8PD2SA95M+BJ2x8h7oLcVOg9qcowWXBOdcTRsMZiwvM3EyLm9AfA==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+			"integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.5.0"
+				"@octokit/types": "^13.10.0"
 			},
 			"engines": {
 				"node": ">= 18"
@@ -662,15 +664,16 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
-			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
+			"integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^10.0.0",
-				"@octokit/request-error": "^6.0.1",
-				"@octokit/types": "^13.1.0",
+				"@octokit/endpoint": "^10.1.3",
+				"@octokit/request-error": "^6.1.7",
+				"@octokit/types": "^13.6.2",
+				"fast-content-type-parse": "^2.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -678,13 +681,13 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
-			"integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
+			"integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.0.0"
+				"@octokit/types": "^13.6.2"
 			},
 			"engines": {
 				"node": ">= 18"
@@ -720,12 +723,13 @@
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
+				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -1370,6 +1374,19 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/async-folder-walker": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/async-folder-walker/-/async-folder-walker-3.0.5.tgz",
+			"integrity": "sha512-Ht724SSn5YNDfptZrFWjnKVNBuiEgEi35d+rutQf3/7iJwx8qUuR5qFSST4eR50qCTyJCq+2PEQw/U4pHdMiBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ignore": "^5.1.8"
+			},
+			"peerDependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/async-settle": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/async-settle/-/async-settle-2.0.0.tgz",
@@ -1403,9 +1420,9 @@
 			"dev": true
 		},
 		"node_modules/axios": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+			"integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2504,6 +2521,23 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/fast-content-type-parse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+			"integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -5246,10 +5280,11 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.28.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},

--- a/tools/package.json
+++ b/tools/package.json
@@ -41,6 +41,7 @@
 		"@types/unzipper": "^0.10.9",
 		"@typescript-eslint/eslint-plugin": "^7.8.0",
 		"@typescript-eslint/parser": "^7.8.0",
+		"async-folder-walker": "^3.0.5",
 		"axios": "^1.6.8",
 		"axios-retry": "^4.1.0",
 		"case-switcher-js": "^1.1.10",

--- a/tools/tasks/helpers/langExtract.ts
+++ b/tools/tasks/helpers/langExtract.ts
@@ -1,0 +1,66 @@
+/* Extracts Lang Files without Formatting Marks, for Typo Checking */
+
+import { langDestDirectory, typoCheckDirectory } from "#globals";
+import { allFiles } from "async-folder-walker";
+import fs from "fs";
+import upath from "upath";
+import { deleteAsync } from "del";
+
+const extractor = /^(.*?)=(.*)$/gm;
+
+export async function extractTypoCheckFiles() {
+	await deleteAsync(upath.join(typoCheckDirectory, "*"), { force: true });
+
+	if (!fs.existsSync(typoCheckDirectory)) {
+		await fs.promises.mkdir(typoCheckDirectory, { recursive: true });
+	}
+
+	const files = await allFiles(upath.join(langDestDirectory, "assets"), {
+		statFilter: (st) => !st.isDirectory(),
+		shaper: (fwData) => fwData,
+	});
+
+	for (const file of files) {
+		let contents = await fs.promises.readFile(file.filepath, "utf8");
+		contents = contents.replaceAll(extractor, (match, p1, p2) => {
+			if (!p2 || typeof p2 !== "string") return match;
+
+			return `${p1}=${removeFormatting(p2)}`;
+		});
+
+		const directory = upath.dirname(
+			upath.join(typoCheckDirectory, file.relname),
+		);
+		if (!fs.existsSync(directory))
+			await fs.promises.mkdir(directory, { recursive: true });
+
+		await fs.promises.writeFile(
+			upath.join(typoCheckDirectory, file.relname),
+			contents,
+		);
+	}
+}
+
+export function removeFormatting(input: string): string {
+	if (!input.includes("§") && !input.includes("%")) return input;
+
+	const builder: string[] = [];
+	for (let i = 0; i < input.length; i++) {
+		const char = input.charAt(i);
+
+		let found = false;
+		for (const exclusion of ["§", "%"]) {
+			if (char === exclusion) {
+				if (input.charAt(i + 1) === exclusion) builder.push(exclusion); // Only include one
+
+				i++; // Skip Next Character
+
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) builder.push(char);
+	}
+	return builder.join("");
+}

--- a/tools/tasks/lang/index.ts
+++ b/tools/tasks/lang/index.ts
@@ -85,3 +85,5 @@ export default series(
 	copyLangChangelog,
 	copyLangUpdateNotes,
 );
+
+export const typoBuild = series(langCleanUp, createLangDirs, copyLangFiles);

--- a/tools/tasks/shared/index.ts
+++ b/tools/tasks/shared/index.ts
@@ -217,3 +217,10 @@ export const buildChangelog = gulp.series(
 	createSharedDirs,
 	fetchOrMakeChangelog,
 );
+
+export const fastTypoBuild = gulp.series(
+	sharedCleanUp,
+	createSharedDirs,
+	copyOverrides,
+	transformQuestBook,
+);

--- a/tools/tasks/shared/index.ts
+++ b/tools/tasks/shared/index.ts
@@ -218,7 +218,7 @@ export const buildChangelog = gulp.series(
 	fetchOrMakeChangelog,
 );
 
-export const fastTypoBuild = gulp.series(
+export const typoBuild = gulp.series(
 	sharedCleanUp,
 	createSharedDirs,
 	copyOverrides,


### PR DESCRIPTION
This PR is heavily inspired by the great efforts in #1250, and attempts to pull together a *somewhat* working system, that is reliable, to checking for typos.

Like #1250, this system uses https://github.com/crate-ci/typos. This system runs on the `checks` workflow task.

Checks are limited to lang files (including extracted QB titles and descriptions), with lang files having the formatting from them stripped (including substitution areas like %1), and files in the `.github` folder. Whilst #1250 did contain some typo fixes for code, this is not included in this PR.

Result:
Hopefully a large reduction in typos, especially for the quest book.