### PR TITLE
Fix Fractionating Distillery Edge Case Crash

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6333765,
+      "fileID": 6335086,
       "required": true
     },
     {


### PR DESCRIPTION
This PR fixes an edge case fractionating distillery bug, caused by setting it to distillery mode, exiting the world, and then changing it to distillation tower mode.

Fixes #1256

This issue was fixed by a mixin in Labs, therefore this PR also updates Nomi Labs to v0.14.4.