### PR TITLE
Expand Typo CI to Cover READMEs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           files: build/typo-check/
 
-      - name: GitHub Workflow and Templates Typo Check
+      - name: Other Misc Typo Check
         uses: crate-ci/typos@v1
         with:
-          files: .github/
+          files: .github/ README.md overrides/README.md


### PR DESCRIPTION
This PR expands the new typo checks to also cover both `README.md` and `overrides/README.md`.