### PR TITLE
Rework Yields for the EM Separator

### DIFF
--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -28,12 +28,12 @@ mods.gregtech.centrifuge.recipeBuilder()
     .buildAndRegister()
 
 // Rework the EM Separator for Naquadah (More Enriched Naquadah, Less Naquadah)
-mods.gregtech.electromagnetic_separator.changeByInput(24, [metaitem('dustPureNaquadah')], null)
+mods.gregtech.electromagnetic_separator.changeByInput([metaitem('dustPureNaquadah')], null)
 	.builder { RecipeBuilder builder ->
 		builder.clearChancedOutput().clearOutputs()
-			.outputs(item('gregtech:meta_dust', 125))
-			.chancedOutput(item('gregtech:meta_dust', 125), 2000, 500)
-			.chancedOutput(item('gregtech:meta_dust', 124), 5000, 375)
+			.outputs(metaitem('dustNaquadahEnriched'))
+			.chancedOutput(metaitem('dustNaquadahEnriched'), 2000, 500)
+			.chancedOutput(metaitem('dustNaquadah'), 5000, 375)
 	}.replaceAndRegister()
 
 // Nether Star Block -> Nether Star

--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -27,7 +27,7 @@ mods.gregtech.centrifuge.recipeBuilder()
     .duration(64).EUt(VA[LV])
     .buildAndRegister()
 
-// Rework the EM Separator for Naquadah (More Enriched Naquadah, less Naquadah)
+// Rework the EM Separator for Naquadah (More Enriched Naquadah, Less Naquadah)
 mods.gregtech.electromagnetic_separator.changeByInput(24, [metaitem('dustPureNaquadah')], null)
 	.builder { RecipeBuilder builder ->
 		builder.clearChancedOutput().clearOutputs()

--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -31,9 +31,9 @@ mods.gregtech.centrifuge.recipeBuilder()
 mods.gregtech.electromagnetic_separator.changeByInput(24, [metaitem('dustPureNaquadah')], null)
 	.builder { RecipeBuilder builder ->
 		builder.clearChancedOutput().clearOutputs()
+			.outputs(item('gregtech:meta_dust', 125))
 			.chancedOutput(item('gregtech:meta_dust', 125), 2000, 500)
 			.chancedOutput(item('gregtech:meta_dust', 124), 5000, 375)
-			.outputs(item('gregtech:meta_dust', 125))
 	}.replaceAndRegister()
 
 // Nether Star Block -> Nether Star

--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -27,6 +27,15 @@ mods.gregtech.centrifuge.recipeBuilder()
     .duration(64).EUt(VA[LV])
     .buildAndRegister()
 
+// Rework the EM Separator for Naquadah (More Enriched Naquadah, less Naquadah)
+mods.gregtech.electromagnetic_separator.changeByInput(24, [metaitem('dustPureNaquadah')], null)
+	.builder { RecipeBuilder builder ->
+		builder.clearChancedOutput().clearOutputs()
+			.chancedOutput(item('gregtech:meta_dust', 125), 2000, 500)
+			.chancedOutput(item('gregtech:meta_dust', 124), 5000, 375)
+			.outputs(item('gregtech:meta_dust', 125))
+	}.replaceAndRegister()
+
 // Nether Star Block -> Nether Star
 crafting.addShapeless(item('minecraft:nether_star') * 9, [ore('blockNetherStar')])
 


### PR DESCRIPTION
Another really simple PR. Mostly a balance decision to be discussed. 
Implements one of the fixes from #1260 .

-> Buffs enriched naquadah from `15% + 4%` to `1 & 20% + 5%` (from +320%(UIV) to +800%(LV) based on tier(and +185%/+860% compared to Thermal centrifuge))

-> Nerfs normal naquadah from 1 to `50% + 3.75%`

This is a huge buff to the output but is balanced since enriched naquadah has very little uses, and naquadah is way more useful, being useful as is, and to make naquadria through naqline.

This is not enough to make the EM separator really useful, but at least it has ONE niche use, getting easy enriched naquadah for trinium coils. That being said, it's kinda sad that enriched naq doesn't have more uses too. It would also give more naquadria than the regular naq recipe if using the fusion recipe to get it, but since it's MK. III and only in NM, I don't think it will see any use. 