### PR TITLE
Reduce Plutonium 239 Fusion Recipe Power Consumption

### DIFF
--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -51,6 +51,7 @@ advanced {
         gregtech/api/recipes/recipeproperties/ScanProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TotalComputationProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
+        gregtech/api/recipes/recipeproperties/FusionEUToStartProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
         gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
      >

--- a/overrides/groovy/postInit/main/general/lateGame/lategame.groovy
+++ b/overrides/groovy/postInit/main/general/lateGame/lategame.groovy
@@ -1,11 +1,23 @@
 package postInit.main.general.lateGame
 
+import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import gregtech.api.recipes.builders.ImplosionRecipeBuilder
+import gregtech.api.recipes.recipeproperties.FusionEUToStartProperty
 import net.minecraft.item.ItemStack
 
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
+
+// Plutonium 239 Fusion Recipe
+// Energy to Start is displayed as MK I level, but because of ZPM voltage, MK II is required.
+// Bump energy req down to LuV to avoid confusion.
+mods.gregtech.fusion_reactor.changeByOutput(null, [fluid('plutonium')])
+	.forEach { ChangeRecipeBuilder builder ->
+		builder.builder { it.EUt(VA[LuV]) }
+			.copyProperties(FusionEUToStartProperty.instance)
+			.replaceAndRegister()
+	}
 
 // Omnium Implosion Compressor Recipes
 ImplosionRecipeBuilder builder = mods.gregtech.implosion_compressor.recipeBuilder()


### PR DESCRIPTION
This PR reduces P239's fusion power consumption down to LuV, allowing it to be performed with MK I fusion reactors, reducing confusion.

Fixes #1230 