### PR TITLE
Hide Thermal Excavators from JEI

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/thermal.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/thermal.groovy
@@ -36,6 +36,13 @@ mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 656)) // Isen
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 672)) // Closed Loop Cooling
 mods.jei.ingredient.removeAndHide(item('thermalexpansion:augment', 704)) // Disjunctive Extraction
 
+/* Other Hiding */
+// Excavators
+// (Replaced by GTCEu Spades)
+mods.jei.ingredient.removeAndHide(item('redstonearsenal:tool.excavator_flux'))
+mods.jei.ingredient.removeAndHide(item('thermalfoundation:tool.excavator_diamond'))
+mods.jei.ingredient.removeAndHide(item('thermalfoundation:tool.excavator_iron'))
+
 /* Upgrade Recipes */
 // Machines (Do each manually, side cache varies)
 createAllUpgradeRecipes(item('thermalexpansion:machine', 4) // Phytogenic Insolator


### PR DESCRIPTION
This PR removes Thermal Foundation and Redstone Flux's Excavators from JEI, as their functionality has been replaced by GTCEu Spades.