### PR TITLE
Add OreDict to Radium Salt

### DIFF
--- a/overrides/groovy/postInit/main/general/midGame/midgame.groovy
+++ b/overrides/groovy/postInit/main/general/midGame/midgame.groovy
@@ -48,6 +48,9 @@ if (LabsModeHelper.expert) {
 		.buildAndRegister()
 }
 
+// Add Ore Dict for Radium Salt
+ore('dustRadiumSalt').add(item('nomilabs:radiumsalt'))
+
 /* Nuclear Related Chanced Output Changes */
 
 // Buff Thorium Yields from Black Granite


### PR DESCRIPTION
This PR simply adds the ore `dustRadiumSalt` to Radium Salt, following https://github.com/Nomifactory/Nomifactory/commit/772762e33d224058de8e3b7ff2d6a2969954d146.