### PR TITLE
Disable CCL Error Chat Messages

### DIFF
--- a/overrides/config/codechickenlib.cfg
+++ b/overrides/config/codechickenlib.cfg
@@ -19,5 +19,5 @@
 
 	#With this enabled, CCL will message the player upon an exception from rendering blocks or items.
 	#Messages are Rate-Limited to one per 5 seconds in the event that the exception continues.
-	B:"messagePlayerOnRenderCrashCaught"=true
+	B:"messagePlayerOnRenderCrashCaught"=false
 }


### PR DESCRIPTION
This PR technically fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1271.

But, instead of fixing the root cause, it stops CCL from printing error chat messages.

Or perhaps, we should not merge for future bug visibility.

Fixes #1271