### PR TITLE
Fix Double Function Removing in Labs Config

### DIFF
--- a/overrides/config/nomilabs.cfg
+++ b/overrides/config/nomilabs.cfg
@@ -51,7 +51,6 @@ advanced {
         gregtech/api/recipes/recipeproperties/ScanProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TemperatureProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/api/recipes/recipeproperties/TotalComputationProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
-        gregtech/api/recipes/recipeproperties/FusionEUToStartProperty@drawInfo@(Lnet/minecraft/client/Minecraft;IIILjava/lang/Object;)V
         gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
         gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank@getParticleTexture@()Lorg/apache/commons/lang3/tuple/Pair;
      >


### PR DESCRIPTION
This PR removes a very stupid mistake I made in #1265, where I added `FusionEuToStartProperty`'s `drawInfo` to be removed, when it was already included in the list, due to my paranoia previously.

Fixes #1279