### PR TITLE
Fix Erroring Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -563,7 +563,7 @@
     },
     {
       "projectID": 419286,
-      "fileID": 5079135,
+      "fileID": 6344449,
       "required": true
     },
     {
@@ -578,7 +578,7 @@
     },
     {
       "projectID": 460609,
-      "fileID": 6344449,
+      "fileID": 6333774,
       "required": true
     },
     {

--- a/tools/utils/curseForgeAPI.ts
+++ b/tools/utils/curseForgeAPI.ts
@@ -65,23 +65,32 @@ export async function fetchFileInfo(
 		return fetchedFileInfoCache[slug];
 	}
 
-	const fileInfo: CurseForgeFileInfo = (
-		await getAxios()({
-			url: `${buildConfig.cfCoreApiEndpoint}/v1/mods/${projectID}/files/${fileID}`,
-			method: "get",
-			responseType: "json",
-			headers: {
-				"X-Api-Key": getCurseForgeToken(),
-			},
-		})
-	).data?.data;
+	let fileInfo: CurseForgeFileInfo | undefined;
+	try {
+		fileInfo = (
+			await getAxios()({
+				url: `${buildConfig.cfCoreApiEndpoint}/v1/mods/${projectID}/files/${fileID}`,
+				method: "get",
+				responseType: "json",
+				headers: {
+					"X-Api-Key": getCurseForgeToken(),
+				},
+			})
+		).data?.data;
+	} catch (e) {
+		// Usually a 404, aka bad json
+		throw new Error(
+			`Failed to get info of file from project ${projectID} with fileID ${fileID}!\n${e}`,
+		);
+	}
 
 	if (!fileInfo) {
-		throw new Error(`Failed to download file ${projectID}/file/${fileID}`);
+		throw new Error(
+			`Failed to get info of file from project ${projectID} with fileID ${fileID}!`,
+		);
 	}
 
 	fetchedFileInfoCache[slug] = fileInfo;
-
 	return fileInfo;
 }
 


### PR DESCRIPTION
Improves logging for incorrect project/file id specification, and fixes incorrect project/file id specification caused by #1275.