### PR TITLE
Remove Useless Recipes in Thermal Compactor

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/thermal.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/thermal.groovy
@@ -147,12 +147,12 @@ void createUpgradeRecipe(ItemStack result, ItemStack toUpgrade, ItemStack upgrad
 List<ItemStack> ingots = [
 	item('advancedrocketry:productingot'), // Titanium Aluminide
 	item('advancedrocketry:productingot', 1), // Titanium Iridium Alloy
-	item('nuclearcraft:ingot', 12), // Aluminum
+	item('nuclearcraft:ingot', 12), // Aluminium
 	item('thermalfoundation:material', 128), // Copper
 	item('thermalfoundation:material', 129), // Tin
 	item('thermalfoundation:material', 130), // Silver
 	item('thermalfoundation:material', 131), // Lead
-	item('thermalfoundation:material', 132), // Aluminum
+	item('thermalfoundation:material', 132), // Aluminium
 	item('thermalfoundation:material', 133), // Nickel
 	item('thermalfoundation:material', 134), // Platinum
 	item('thermalfoundation:material', 135), // Iridium
@@ -167,4 +167,6 @@ List<ItemStack> ingots = [
 ]
 ingots.forEach { mods.thermalexpansion.compactor.removeByInput(it) }
 
-mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material', 264)) // Mana Infused Gear
+// Mana Infused Gear
+mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material', 264))
+mods.jei.hide(item('thermalfoundation:material', 264)) // Mana Infused Gear

--- a/overrides/groovy/postInit/main/modSpecific/thermal.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/thermal.groovy
@@ -143,3 +143,28 @@ void createUpgradeRecipe(ItemStack result, ItemStack toUpgrade, ItemStack upgrad
 		.register()
 }
 
+/* Remove Obsolete Recipes */
+List<ItemStack> ingots = [
+	item('advancedrocketry:productingot'), // Titanium Aluminide
+	item('advancedrocketry:productingot', 1), // Titanium Iridium Alloy
+	item('nuclearcraft:ingot', 12), // Aluminum
+	item('thermalfoundation:material', 128), // Copper
+	item('thermalfoundation:material', 129), // Tin
+	item('thermalfoundation:material', 130), // Silver
+	item('thermalfoundation:material', 131), // Lead
+	item('thermalfoundation:material', 132), // Aluminum
+	item('thermalfoundation:material', 133), // Nickel
+	item('thermalfoundation:material', 134), // Platinum
+	item('thermalfoundation:material', 135), // Iridium
+	item('thermalfoundation:material', 160), // Steel
+	item('thermalfoundation:material', 161), // Electrum
+	item('thermalfoundation:material', 162), // Invar
+	item('thermalfoundation:material', 163), // Bronze
+	item('thermalfoundation:material', 164), // Constantan
+	item('thermalfoundation:material', 165), // Signalum
+	item('thermalfoundation:material', 166), // Lumium
+	item('thermalfoundation:material', 167), // Enderium
+]
+ingots.forEach { mods.thermalexpansion.compactor.removeByInput(it) }
+
+mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material', 264)) // Mana Infused Gear

--- a/overrides/groovy/postInit/main/modSpecific/thermal.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/thermal.groovy
@@ -43,6 +43,9 @@ mods.jei.ingredient.removeAndHide(item('redstonearsenal:tool.excavator_flux'))
 mods.jei.ingredient.removeAndHide(item('thermalfoundation:tool.excavator_diamond'))
 mods.jei.ingredient.removeAndHide(item('thermalfoundation:tool.excavator_iron'))
 
+// Unused Items
+mods.jei.hide(item('thermalfoundation:material', 264)) // Mana Infused Gear
+
 /* Upgrade Recipes */
 // Machines (Do each manually, side cache varies)
 createAllUpgradeRecipes(item('thermalexpansion:machine', 4) // Phytogenic Insolator
@@ -167,6 +170,4 @@ List<ItemStack> ingots = [
 ]
 ingots.forEach { mods.thermalexpansion.compactor.removeByInput(it) }
 
-// Mana Infused Gear
-mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material', 264))
-mods.jei.hide(item('thermalfoundation:material', 264)) // Mana Infused Gear
+mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material', 264)) // Mana Infused Gear


### PR DESCRIPTION
I have no clue why I waited so long, had it stashed since friday.

Removes by input any recipe with unobtainable ingots/materials. Made sure that it ignores mana infused, since the Mana infused plates are kept. 
Also didn't do what I wanted to do originally (remove the Uranium Oxide recipe), since it actually uses the Uranium Oredict, so there's actually not any problems.

Feel free to reject this commit if you feel it adds useless load time. It's really up to you, it's a pack direction decision. So, don't feel bad if you feel it doesn't fit.