### PR TITLE
Downgrade Mixinbooter Back to v9.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -563,7 +563,7 @@
     },
     {
       "projectID": 419286,
-      "fileID": 6344449,
+      "fileID": 5640857,
       "required": true
     },
     {


### PR DESCRIPTION
This PR downgrades Mixinbooter to v9.3, fixing the crash outlined in https://github.com/Nomi-CEu/Nomi-CEu/issues/1292.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1292