### PR TITLE
Normalize Quest Fluid Tasks to Require 1 MB

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -1391,7 +1391,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "benzene"
             }
           },
@@ -5670,7 +5670,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sulfuric_acid"
             }
           },
@@ -5725,7 +5725,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethylene"
             }
           },
@@ -5775,7 +5775,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "plastic"
             }
           },
@@ -8837,7 +8837,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "titanium_tetrachloride"
             }
           },
@@ -9633,7 +9633,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "diesel"
             }
           },
@@ -9795,7 +9795,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_air"
             }
           },
@@ -9850,7 +9850,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glycerol"
             }
           },
@@ -9905,7 +9905,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitrogen"
             }
           },
@@ -10013,7 +10013,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "argon"
             }
           },
@@ -10112,7 +10112,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitric_acid"
             }
           },
@@ -10171,7 +10171,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "tetranitromethane"
             }
           },
@@ -10226,7 +10226,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitro_fuel"
             }
           },
@@ -10280,7 +10280,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethenone"
             }
           },
@@ -10334,7 +10334,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "acetic_acid"
             }
           },
@@ -10395,7 +10395,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "epichlorohydrin"
             }
           },
@@ -10515,7 +10515,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil"
             }
           },
@@ -10529,7 +10529,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_medium"
             }
           },
@@ -10543,7 +10543,7 @@
           "index:3": 2,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_light"
             }
           },
@@ -10557,7 +10557,7 @@
           "index:3": 3,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_heavy"
             }
           },
@@ -12315,7 +12315,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -12712,7 +12712,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rocket_fuel"
             }
           },
@@ -12767,7 +12767,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "dimethylhydrazine"
             }
           },
@@ -12911,7 +12911,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ammonia"
             }
           },
@@ -12965,7 +12965,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "methanol"
             }
           },
@@ -13019,7 +13019,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hypochlorous_acid"
             }
           },
@@ -13519,7 +13519,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mana"
             }
           },
@@ -15274,7 +15274,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "radon"
             }
           },
@@ -15764,7 +15764,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "phosphoric_acid"
             }
           },
@@ -17683,7 +17683,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "elementalreduction"
             }
           },
@@ -23466,7 +23466,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fish_oil"
             }
           },
@@ -27199,7 +27199,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethanol"
             }
           },
@@ -27291,7 +27291,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "chlorine"
             }
           },
@@ -27477,7 +27477,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ender_distillation"
             }
           },
@@ -28980,7 +28980,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sterilized_growth_medium"
             }
           },
@@ -40188,7 +40188,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fire_water"
             }
           },
@@ -41391,7 +41391,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "silicone_rubber"
             }
           },
@@ -41405,7 +41405,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "styrene_butadiene_rubber"
             }
           },
@@ -42258,19 +42258,19 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "charcoal_byproducts"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_gas"
             },
             "2:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_vinegar"
             },
             "3:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_tar"
             }
           },
@@ -42499,11 +42499,11 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrogen"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -43397,7 +43397,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_persulfate"
             }
           },
@@ -43411,7 +43411,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "iron_iii_chloride"
             }
           },
@@ -43633,7 +43633,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polytetrafluoroethylene"
             }
           },
@@ -43841,7 +43841,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polybenzimidazole"
             }
           },
@@ -44709,7 +44709,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fluoroantimonic_acid"
             }
           },
@@ -47143,7 +47143,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline"
             }
           },
@@ -47547,7 +47547,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_potassium"
             }
           },
@@ -47696,7 +47696,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrofluoric_acid"
             }
           },
@@ -47750,7 +47750,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline_premium"
             }
           },
@@ -48003,7 +48003,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "bacterial_sludge"
             }
           },
@@ -48056,7 +48056,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mutagen"
             }
           },
@@ -49006,7 +49006,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_nether_air"
             }
           },
@@ -49061,7 +49061,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_ender_air"
             }
           },
@@ -55044,7 +55044,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glue"
             }
           },
@@ -56333,7 +56333,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -57800,7 +57800,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rubber"
             }
           },

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -6794,7 +6794,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sulfuric_acid"
             }
           },
@@ -6866,7 +6866,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethylene"
             }
           },
@@ -6929,7 +6929,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "plastic"
             }
           },
@@ -10535,7 +10535,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "titanium_tetrachloride"
             }
           },
@@ -11450,7 +11450,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "diesel"
             }
           },
@@ -11623,7 +11623,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_air"
             }
           },
@@ -11691,7 +11691,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glycerol"
             }
           },
@@ -11759,7 +11759,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitrogen"
             }
           },
@@ -11893,7 +11893,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "argon"
             }
           },
@@ -12005,7 +12005,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitric_acid"
             }
           },
@@ -12077,7 +12077,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "tetranitromethane"
             }
           },
@@ -12145,7 +12145,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitro_fuel"
             }
           },
@@ -12212,7 +12212,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethenone"
             }
           },
@@ -12279,7 +12279,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "acetic_acid"
             }
           },
@@ -12353,7 +12353,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "epichlorohydrin"
             }
           },
@@ -12499,7 +12499,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil"
             }
           },
@@ -12513,7 +12513,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_medium"
             }
           },
@@ -12527,7 +12527,7 @@
           "index:3": 2,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_heavy"
             }
           },
@@ -12541,7 +12541,7 @@
           "index:3": 3,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_light"
             }
           },
@@ -14606,7 +14606,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -15068,7 +15068,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rocket_fuel"
             }
           },
@@ -15136,7 +15136,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "dimethylhydrazine"
             }
           },
@@ -15293,7 +15293,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ammonia"
             }
           },
@@ -15360,7 +15360,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "methanol"
             }
           },
@@ -15427,7 +15427,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hypochlorous_acid"
             }
           },
@@ -16050,7 +16050,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mana"
             }
           },
@@ -18205,7 +18205,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "radon"
             }
           },
@@ -18812,7 +18812,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "phosphoric_acid"
             }
           },
@@ -21112,7 +21112,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "elementalreduction"
             }
           },
@@ -27566,7 +27566,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fish_oil"
             }
           },
@@ -31507,7 +31507,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethanol"
             }
           },
@@ -31612,7 +31612,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "chlorine"
             }
           },
@@ -31837,7 +31837,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ender_distillation"
             }
           },
@@ -33627,7 +33627,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sterilized_growth_medium"
             }
           },
@@ -46874,7 +46874,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fire_water"
             }
           },
@@ -48276,7 +48276,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "silicone_rubber"
             }
           },
@@ -48290,7 +48290,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "styrene_butadiene_rubber"
             }
           },
@@ -49286,19 +49286,19 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "charcoal_byproducts"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_gas"
             },
             "2:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_vinegar"
             },
             "3:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_tar"
             }
           },
@@ -49695,7 +49695,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "seed_oil"
             }
           },
@@ -50681,7 +50681,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_persulfate"
             }
           },
@@ -50695,7 +50695,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "iron_iii_chloride"
             }
           },
@@ -50960,7 +50960,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polytetrafluoroethylene"
             }
           },
@@ -51207,7 +51207,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polybenzimidazole"
             }
           },
@@ -52255,7 +52255,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fluoroantimonic_acid"
             }
           },
@@ -55298,7 +55298,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline"
             }
           },
@@ -55768,7 +55768,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_potassium"
             }
           },
@@ -55945,7 +55945,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrofluoric_acid"
             }
           },
@@ -56012,7 +56012,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline_premium"
             }
           },
@@ -56292,7 +56292,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "bacterial_sludge"
             }
           },
@@ -56358,7 +56358,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mutagen"
             }
           },
@@ -58404,7 +58404,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "water"
             }
           },
@@ -58455,7 +58455,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "lava"
             }
           },
@@ -58998,7 +58998,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_ender_air"
             }
           },
@@ -59066,7 +59066,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_nether_air"
             }
           },
@@ -59464,7 +59464,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -59530,11 +59530,11 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrogen"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -60024,7 +60024,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "concrete"
             }
           },
@@ -66078,7 +66078,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -6794,7 +6794,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sulfuric_acid"
             }
           },
@@ -6866,7 +6866,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethylene"
             }
           },
@@ -6929,7 +6929,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "plastic"
             }
           },
@@ -10535,7 +10535,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "titanium_tetrachloride"
             }
           },
@@ -11450,7 +11450,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "diesel"
             }
           },
@@ -11623,7 +11623,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_air"
             }
           },
@@ -11691,7 +11691,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glycerol"
             }
           },
@@ -11759,7 +11759,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitrogen"
             }
           },
@@ -11893,7 +11893,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "argon"
             }
           },
@@ -12005,7 +12005,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitric_acid"
             }
           },
@@ -12077,7 +12077,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "tetranitromethane"
             }
           },
@@ -12145,7 +12145,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitro_fuel"
             }
           },
@@ -12212,7 +12212,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethenone"
             }
           },
@@ -12279,7 +12279,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "acetic_acid"
             }
           },
@@ -12353,7 +12353,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "epichlorohydrin"
             }
           },
@@ -12499,7 +12499,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil"
             }
           },
@@ -12513,7 +12513,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_medium"
             }
           },
@@ -12527,7 +12527,7 @@
           "index:3": 2,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_heavy"
             }
           },
@@ -12541,7 +12541,7 @@
           "index:3": 3,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_light"
             }
           },
@@ -14606,7 +14606,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -15068,7 +15068,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rocket_fuel"
             }
           },
@@ -15136,7 +15136,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "dimethylhydrazine"
             }
           },
@@ -15293,7 +15293,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ammonia"
             }
           },
@@ -15360,7 +15360,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "methanol"
             }
           },
@@ -15427,7 +15427,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hypochlorous_acid"
             }
           },
@@ -16050,7 +16050,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mana"
             }
           },
@@ -18205,7 +18205,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "radon"
             }
           },
@@ -18812,7 +18812,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "phosphoric_acid"
             }
           },
@@ -21112,7 +21112,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "elementalreduction"
             }
           },
@@ -27566,7 +27566,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fish_oil"
             }
           },
@@ -31507,7 +31507,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethanol"
             }
           },
@@ -31612,7 +31612,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "chlorine"
             }
           },
@@ -31837,7 +31837,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ender_distillation"
             }
           },
@@ -33627,7 +33627,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sterilized_growth_medium"
             }
           },
@@ -46874,7 +46874,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fire_water"
             }
           },
@@ -48276,7 +48276,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "silicone_rubber"
             }
           },
@@ -48290,7 +48290,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "styrene_butadiene_rubber"
             }
           },
@@ -49286,19 +49286,19 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "charcoal_byproducts"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_gas"
             },
             "2:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_vinegar"
             },
             "3:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_tar"
             }
           },
@@ -49695,7 +49695,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "seed_oil"
             }
           },
@@ -50681,7 +50681,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_persulfate"
             }
           },
@@ -50695,7 +50695,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "iron_iii_chloride"
             }
           },
@@ -50960,7 +50960,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polytetrafluoroethylene"
             }
           },
@@ -51207,7 +51207,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polybenzimidazole"
             }
           },
@@ -52255,7 +52255,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fluoroantimonic_acid"
             }
           },
@@ -55298,7 +55298,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline"
             }
           },
@@ -55768,7 +55768,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_potassium"
             }
           },
@@ -55945,7 +55945,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrofluoric_acid"
             }
           },
@@ -56012,7 +56012,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline_premium"
             }
           },
@@ -56292,7 +56292,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "bacterial_sludge"
             }
           },
@@ -56358,7 +56358,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mutagen"
             }
           },
@@ -58404,7 +58404,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "water"
             }
           },
@@ -58455,7 +58455,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "lava"
             }
           },
@@ -58998,7 +58998,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_ender_air"
             }
           },
@@ -59066,7 +59066,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_nether_air"
             }
           },
@@ -59464,7 +59464,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -59530,11 +59530,11 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrogen"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -60024,7 +60024,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "concrete"
             }
           },
@@ -66078,7 +66078,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -1391,7 +1391,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "benzene"
             }
           },
@@ -5670,7 +5670,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sulfuric_acid"
             }
           },
@@ -5725,7 +5725,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethylene"
             }
           },
@@ -5775,7 +5775,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "plastic"
             }
           },
@@ -8837,7 +8837,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "titanium_tetrachloride"
             }
           },
@@ -9633,7 +9633,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "diesel"
             }
           },
@@ -9795,7 +9795,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_air"
             }
           },
@@ -9850,7 +9850,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glycerol"
             }
           },
@@ -9905,7 +9905,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitrogen"
             }
           },
@@ -10013,7 +10013,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "argon"
             }
           },
@@ -10112,7 +10112,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitric_acid"
             }
           },
@@ -10171,7 +10171,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "tetranitromethane"
             }
           },
@@ -10226,7 +10226,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "nitro_fuel"
             }
           },
@@ -10280,7 +10280,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethenone"
             }
           },
@@ -10334,7 +10334,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "acetic_acid"
             }
           },
@@ -10395,7 +10395,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "epichlorohydrin"
             }
           },
@@ -10515,7 +10515,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil"
             }
           },
@@ -10529,7 +10529,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_medium"
             }
           },
@@ -10543,7 +10543,7 @@
           "index:3": 2,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_light"
             }
           },
@@ -10557,7 +10557,7 @@
           "index:3": 3,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oil_heavy"
             }
           },
@@ -12315,7 +12315,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -12712,7 +12712,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rocket_fuel"
             }
           },
@@ -12767,7 +12767,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "dimethylhydrazine"
             }
           },
@@ -12911,7 +12911,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ammonia"
             }
           },
@@ -12965,7 +12965,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "methanol"
             }
           },
@@ -13019,7 +13019,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hypochlorous_acid"
             }
           },
@@ -13519,7 +13519,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mana"
             }
           },
@@ -15274,7 +15274,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "radon"
             }
           },
@@ -15764,7 +15764,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "phosphoric_acid"
             }
           },
@@ -17683,7 +17683,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "elementalreduction"
             }
           },
@@ -23466,7 +23466,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fish_oil"
             }
           },
@@ -27199,7 +27199,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ethanol"
             }
           },
@@ -27291,7 +27291,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "chlorine"
             }
           },
@@ -27477,7 +27477,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "ender_distillation"
             }
           },
@@ -28980,7 +28980,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sterilized_growth_medium"
             }
           },
@@ -40188,7 +40188,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fire_water"
             }
           },
@@ -41391,7 +41391,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "silicone_rubber"
             }
           },
@@ -41405,7 +41405,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "styrene_butadiene_rubber"
             }
           },
@@ -42258,19 +42258,19 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "charcoal_byproducts"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_gas"
             },
             "2:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_vinegar"
             },
             "3:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "wood_tar"
             }
           },
@@ -42499,11 +42499,11 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrogen"
             },
             "1:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "oxygen"
             }
           },
@@ -43397,7 +43397,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_persulfate"
             }
           },
@@ -43411,7 +43411,7 @@
           "index:3": 1,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "iron_iii_chloride"
             }
           },
@@ -43633,7 +43633,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polytetrafluoroethylene"
             }
           },
@@ -43841,7 +43841,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "polybenzimidazole"
             }
           },
@@ -44709,7 +44709,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "fluoroantimonic_acid"
             }
           },
@@ -47143,7 +47143,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline"
             }
           },
@@ -47547,7 +47547,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "sodium_potassium"
             }
           },
@@ -47696,7 +47696,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "hydrofluoric_acid"
             }
           },
@@ -47750,7 +47750,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "gasoline_premium"
             }
           },
@@ -48003,7 +48003,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "bacterial_sludge"
             }
           },
@@ -48056,7 +48056,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "mutagen"
             }
           },
@@ -49006,7 +49006,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_nether_air"
             }
           },
@@ -49061,7 +49061,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "liquid_ender_air"
             }
           },
@@ -55044,7 +55044,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "glue"
             }
           },
@@ -56333,7 +56333,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "deuterium"
             }
           },
@@ -57800,7 +57800,7 @@
           "index:3": 0,
           "requiredFluids:9": {
             "0:10": {
-              "Amount:3": 1000,
+              "Amount:3": 1,
               "FluidName:8": "rubber"
             }
           },

--- a/tools/tasks/helpers/questChecks/index.ts
+++ b/tools/tasks/helpers/questChecks/index.ts
@@ -306,6 +306,30 @@ async function checkAndFixQB(
 			}
 		}
 
+		// Check for Fluid Tasks' Amount
+		for (const task of Object.values(quest["tasks:9"])) {
+			if (task["taskID:8"] !== "bq_standard:fluid") continue;
+
+			const reqFluids = task["requiredFluids:9"] as Record<
+				string,
+				Record<string, unknown>
+			>;
+			if (!reqFluids) return;
+			for (const fluid of Object.values(reqFluids)) {
+				if (fluid["Amount:3"] === 1) continue;
+
+				if (shouldCheck)
+					throw new Error(
+						`Task with Index ${task["index:3"]} in Quest with ID ${foundID} has Fluid with Amount ≠ 1!`,
+					);
+
+				logWarn(
+					`Fixing Required Fluid Amount of Task with Index ${task["index:3"]} in Quest with ID ${foundID}...`,
+				);
+				fluid["Amount:3"] = 1;
+			}
+		}
+
 		// Check for Rewards that have Nomicoins
 		if (isExpert) stripRewards(quest, shouldCheck, true);
 

--- a/tools/types/bqQuestBook.ts
+++ b/tools/types/bqQuestBook.ts
@@ -14,7 +14,7 @@ export interface Quest {
 	"tasks:9": { [key: string]: Task };
 }
 
-export interface Task {
+export interface Task extends Record<string, unknown> {
 	"index:3": number;
 	"taskID:8": string;
 }


### PR DESCRIPTION
This PR adds an automatic formatting and checking task to ensure all fluid quest tasks require only 1MB, and normalizes the existing tasks.

This can help with making quests like this less annoying, especially when the recipe outputs a small amount, such as liquid rubber.