### PR TITLE
Patch Out AE2 Issues

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6428446,
+      "fileID": 6436338,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -620,7 +620,7 @@
     },
     {
       "projectID": 570458,
-      "fileID": 5411078,
+      "fileID": 5378163,
       "required": true
     },
     {


### PR DESCRIPTION
This PR downgrades AE2 back to v0.56.5, and upgrades Labs to 0.15.0, which provides patches porting fixes from later versions of ae2 back to the stable 0.56.5.

This leads to:
- Cache Collision Fix
- Interface Deadlocking Fix
- OreDict Storage Bus Copying Fix
- Shift Clicking Fixes
- Portable Cell and Wireless Terminal Dupes and Voids
- Interface Terminal Localization Fix
- Sticky Card and Crafting Fix
- Fix PMT Buttons on Interface Terminal
- Fix NAE2 Fluid Cells Deconstructing into Item Components

As well as:
- Display of Interface Locking in GUI
- Allow Looking Up Fluids in AE2 Slots in JEI
- Autofocusing Wireless Fluid Terminal
- Allowing Holding Keys whilst Searching in Various Terminals and Advanced Memory Card
- Fixing Ore Storage Bus and Renaming not Saving on Escape

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1289
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1251