### PR TITLE
Fix Gemstone Lenses Not Working on Dedicated Servers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6436338,
+      "fileID": 6438352,
       "required": true
     },
     {


### PR DESCRIPTION
This PR fixes gemstone lenses not working on dedicated servers, by updating labs to 0.15.1.

Basically:

The original lens bug (https://github.com/Nomi-CEu/Nomi-CEu/issues/708) was fixed in https://github.com/GregTechCEu/GregTech/pull/2456.  

However, the time when the cache gets reset is different depending on mods loaded. In our case, since JEI is loaded, the cache is reset not on load complete or script load, but on JEI load.

Interestingly, the registration of plugins doesn’t seem to occur on dedicated servers, supported by data in the logs, and the old issue reports where people complained about non-working recipes that showed up in JEI, due to them being on a server with a different mode.

The Labs update fixes this issue by invalidating the cache post groovy script load, on dedicated servers only.