### PR TITLE
Fix Impossible ZBGT Recipes

### DIFF
--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -118,7 +118,7 @@ if (LabsModeHelper.normal) {
 			ore('circuitUv') * 16,
 			metaitem('field.generator.luv') * 16,
 			metaitem('springNaquadahAlloy') * 16,
-			metaitem('plateDenseNaquadahAlloy') * 16,
+			metaitem('plateNaquadahAlloy') * 16,
 			metaitem('wireGtHexUraniumRhodiumDinaquadide') * 16
 		)
 		.fluidInputs(fluid('soldering_alloy') * 9216)
@@ -157,7 +157,7 @@ if (LabsModeHelper.normal) {
 			ore('circuitUv') * 16,
 			metaitem('field.generator.luv') * 16,
 			metaitem('pipeNormalFluidNaquadah') * 16,
-			metaitem('plateDenseNaquadahAlloy') * 16,
+			metaitem('plateNaquadahAlloy') * 16,
 			metaitem('wireGtHexUraniumRhodiumDinaquadide') * 16
 		)
 		.fluidInputs(fluid('soldering_alloy') * 9216)
@@ -173,7 +173,7 @@ if (LabsModeHelper.normal) {
 			ore('circuitUhv') * 16,
 			metaitem('field.generator.uv') * 16,
 			metaitem('pipeNormalFluidDuranium') * 16,
-			metaitem('plateDenseTritanium') * 16,
+			metaitem('plateTritanium') * 16,
 			metaitem('wireGtHexUraniumRhodiumDinaquadide') * 16
 		)
 		.fluidInputs(fluid('soldering_alloy') * 9216)


### PR DESCRIPTION
This PR fixes the ZBGT recipes for the mega ebf (NM) and mega freezer (NM and HM) being impossible, due to dense plates having a stack size below the requested (they stack to 7, requested 16).