### PR TITLE
Fix Drums Being Voided in Fluid Crafting

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
+++ b/overrides/groovy/postInit/main/general/misc/fluidCrafting.groovy
@@ -432,10 +432,8 @@ class IngredientFluidBucket extends SimpleIIngredient {
 
 	@Override
 	ItemStack applyTransform(ItemStack matchedInput) {
-		matchedInput = matchedInput.copy()
-
-		if (matchedInput.getItem().hasContainerItem(matchedInput))
-			return super.applyTransform(matchedInput)
+		// Technically, we could use containerItem logic (e.g. super's logic) for GT Drums, Super Tanks, etc.
+		// But leads to voiding if we don't normalize stack size to 1, and its just easier to use this logic for all.
 
 		var handler = getHandler(matchedInput)
 		if (handler == null) return super.applyTransform(matchedInput)
@@ -449,8 +447,8 @@ class IngredientFluidBucket extends SimpleIIngredient {
 
 		IFluidHandlerItem handler = null
 		if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+			itemStack = itemStack.copy()
 			if (itemStack.getCount() > 1) {
-				itemStack = itemStack.copy()
 				itemStack.setCount(1)
 			}
 			handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)


### PR DESCRIPTION
This PR fixes an edge case in fluid crafting, when stacked drums were used and then the recipe was attempted to be mass-crafted.

This caused one of the drum items to disappear (not leaving behind an empty drum), as well as most of its contents.

This was due to GT’s internal container item being delegated to for this, which did not work perfectly (notably not normalizing the stack size to 1), leading to voiding.

This PR completely removes the dependency on the internal logic, using our custom logic for all items, fixing potential uncaught edge cases as well.

~~I have discovered: Super Tanks can be used for fluid crafting…~~