### PR TITLE
Fix Fueling Station in Edge Case Environments

### DIFF
--- a/overrides/config/advRocketry/advancedRocketry.cfg
+++ b/overrides/config/advRocketry/advancedRocketry.cfg
@@ -390,6 +390,7 @@ rockets {
     # List of fluid names for fluids that can be used as rocket fuel
     S:rocketFuels <
         rocket_fuel
+        rocketfuel
      >
     S:rocketOxidizers <
         oxygen


### PR DESCRIPTION
The rest bugs. I think we should ban the access right to land on gas giant. If you try to land on it, then you will achieve an infinite void.

@IntegerLimit 
I make it only change one file.