### PR TITLE
Update ZBGT Addon script

### DIFF
--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -21,6 +21,7 @@ crafting.remove('zbgt:creative_energy_hatch_to_emitter')
 // Creative Item Bus (Useless since you already have chest)
 crafting.remove('zbgt:creative_item_bus_to_chest')
 crafting.remove('zbgt:creative_chest_to_item_bus')
+mods.jei.ingredient.removeAndHide(item('gregtech:machine', 18008)) // Creative Item Bus
 
 // Creative Tank
 crafting.remove('zbgt:creative_fluid_hatch_to_tank')
@@ -221,3 +222,410 @@ if (LabsModeHelper.normal) {
 		.duration(1200).EUt(VA[UV])
 		.buildAndRegister()
 }
+
+/* YOTTank Cells */
+// Add new recipes for YOTTank Cells
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('gregtech:hermetic_casing', 0),
+		metaitem('field.generator.lv'),
+		ore('circuitLv') * 4,
+		metaitem('plateSteel') * 4
+	)
+	.outputs(item('zbgt:yottank_cell', 0))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('gregtech:hermetic_casing', 4),
+		metaitem('field.generator.hv') * 2,
+		ore('circuitIv') * 4,
+		metaitem('plateTungstenSteel') * 4
+	)
+	.outputs(item('zbgt:yottank_cell', 1))
+	.duration(100).EUt(VA[IV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('gregtech:hermetic_casing', 8),
+		metaitem('field.generator.uv') * 2,
+		ore('circuitUv') * 4,
+		metaitem('plateNeutronium') * 4
+	)
+	.outputs(item('zbgt:yottank_cell', 2))
+	.duration(100).EUt(VA[UV])
+	.buildAndRegister()
+
+// Remove other YOTTank Cells from JEI
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 3))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 4))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 5))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 6))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 7))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 8))
+mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 9))
+
+
+/* Wraps */
+// Remove unused wrap crafts and from JEI
+// Wrap of Circuite board and SoC not removed, since other tiers have uses
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 57)], null) // Wrap of ULV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 57))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 58)], null) // Wrap of LV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 58))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 59)], null) // Wrap of MV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 59))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 60)], null) // Wrap of HV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 60))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 61)], null) // Wrap of EV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 61))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 62)], null) // Wrap of IV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 62))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 63)], null) // Wrap of LUV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 63))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 64)], null) // Wrap of ZPM Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 64))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 65)], null) // Wrap of UV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 65))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 66)], null) // Wrap of UHV Circuit
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 66))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 103)], null) // Wrap of PIC Ultra Low Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 103))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 104)], null) // Wrap of PIC Low Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 104))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 105)], null) // Wrap of PIC Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 105))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 106)], null) // Wrap of PIC High Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 106))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 107)], null) // Wrap of PIC Ultra High Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 107))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 111)], null) // Wrap of Integrated Logic Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 111))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 113)], null) // Wrap of Engraved Crystal Chip
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 113))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 82)], null) // Wrap of Coated Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 82))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 83)], null) // Wrap of Phenolic Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 83))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 84)], null) // Wrap of Plastic Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 84))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 85)], null) // Wrap of Epoxy Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 85))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 86)], null) // Wrap of Fiber Reinforced Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 86))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 87)], null) // Wrap of Multilayer Fiber Reinforced Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 87))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 88)], null) // Wrap of Wetware Board
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 88))
+
+// Add unwrap Crafts
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 72)) // Wrap of SMD Capacitor
+	.circuitMeta(1)
+	.outputs(metaitem('component.smd.capacitor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 73)) // Wrap of SMD Diode
+	.circuitMeta(1)
+	.outputs(metaitem('component.smd.diode') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 74)) // Wrap of SMD Inductor
+	.circuitMeta(1)
+	.outputs(metaitem('component.smd.inductor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 75)) // Wrap of SMD Resistor
+	.circuitMeta(1)
+	.outputs(metaitem('component.smd.resistor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 76)) // Wrap of SMD Transistor
+	.circuitMeta(1)
+	.outputs(metaitem('component.smd.transistor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 77)) // Wrap of Advanced SMD Capacitor
+	.circuitMeta(1)
+	.outputs(metaitem('component.advanced_smd.capacitor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 78)) // Wrap of Advanced SMD Diode
+	.circuitMeta(1)
+	.outputs(metaitem('component.advanced_smd.diode') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 79)) // Wrap of Advanced SMD Inductor
+	.circuitMeta(1)
+	.outputs(metaitem('component.advanced_smd.inductor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 80)) // Wrap of Advanced SMD Resistor
+	.circuitMeta(1)
+	.outputs(metaitem('component.advanced_smd.resistor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 81)) // Wrap of Advanced SMD Transistor
+	.circuitMeta(1)
+	.outputs(metaitem('component.advanced_smd.transistor') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 89)) // Wrap of Basic Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.basic') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 90)) // Wrap of Good Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.good') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 91)) // Wrap of Plastic Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.plastic') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 92)) // Wrap of Advanced Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.advanced') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 93)) // Wrap of Elite Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.elite') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 94)) // Wrap of Extreme Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.extreme') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 95)) // Wrap of Master Circuit Board
+	.circuitMeta(1)
+	.outputs(metaitem('circuit_board.wetware') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 96)) // Wrap of Simple SoC
+	.circuitMeta(1)
+	.outputs(metaitem('plate.simple_system_on_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 97)) // Wrap of SoC
+	.circuitMeta(1)
+	.outputs(metaitem('plate.system_on_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 98)) // Wrap of Advanced SoC
+	.circuitMeta(1)
+	.outputs(metaitem('plate.advanced_system_on_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 99)) // Wrap of Highly Advanced SoC
+	.circuitMeta(1)
+	.outputs(metaitem('plate.highly_advanced_system_on_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 100)) // Wrap of CPU
+	.circuitMeta(1)
+	.outputs(metaitem('plate.central_processing_unit') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 101)) // Wrap of Nano CPU
+	.circuitMeta(1)
+	.outputs(metaitem('plate.nano_central_processing_unit') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 102)) // Wrap of Qubit CPU
+	.circuitMeta(1)
+	.outputs(metaitem('plate.qbit_central_processing_unit') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 108)) // Wrap of RAM
+	.circuitMeta(1)
+	.outputs(metaitem('plate.random_access_memory') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 109)) // Wrap of NOR Chip
+	.circuitMeta(1)
+	.outputs(metaitem('plate.nor_memory_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 110)) // Wrap of NAND Chip
+	.circuitMeta(1)
+	.outputs(metaitem('plate.nand_memory_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 112)) // Wrap of Neuro Processsing Unit
+	.circuitMeta(1)
+	.outputs(metaitem('processor.neuro') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 114)) // Wrap of Chrystal CPU
+	.circuitMeta(1)
+	.outputs(metaitem('crystal.central_processing_unit') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('zbgt:zbgt_meta_item', 115)) // Wrap of Crystal SoC
+	.circuitMeta(1)
+	.outputs(metaitem('crystal.system_on_chip') * 16)
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+/* Cells */
+// Remove unused cells from JEI
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 133)) // 180K Space Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 134)) // 360K Space Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 135)) // 540K Space Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 136)) // 1080K Space Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 143)) // 180K SP Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 144)) // 360K SP Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 145)) // 540K SP Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 146)) // 1080K SP Coolant Cell
+
+// Remove unused filled cell recipes and from JEI
+mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 137)], null) // 60K HE Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 137))
+mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 138)], null) // 180K HE Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 138))
+mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 140)], null) // 60K NaK Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 140))
+mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 141)], null) // 180K NaK Coolant Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 141))
+
+// Remove smaller single craft cells, and compley 60K cell craft
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 130)], null) // 10K Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 130))
+mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 131)], null) // 30K Cell
+mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 131))
+
+mods.gregtech.assembler.removeByInput(120, [
+		item('zbgt:zbgt_meta_item', 131) * 2, // 30K Cell * 2
+		item('gregtech:meta_plate', 112) * 8, // Tin Plates * 8
+		metaitem('circuit.integrated').withNbt(['Configuration': 1])
+	], null)
+
+/* Dropper Cover Assembler recipes */
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		metaitem('conveyor.module.lv'),
+		item('minecraft:dropper'),
+		ore('circuitLv'),
+		metaitem('electric.piston.lv')
+	)
+	.outputs(item('zbgt:zbgt_meta_item', 117)) // LV Dropper Cover
+	.duration(200).EUt(VA[LV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		metaitem('conveyor.module.mv'),
+		item('minecraft:dropper'),
+		ore('circuitMv'),
+		metaitem('electric.piston.mv')
+	)
+	.outputs(item('zbgt:zbgt_meta_item', 118)) // MV Dropper Cover
+	.duration(200).EUt(VA[MV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		metaitem('conveyor.module.hv'),
+		item('minecraft:dropper'),
+		ore('circuitHv'),
+		metaitem('electric.piston.hv')
+	)
+	.outputs(item('zbgt:zbgt_meta_item', 119)) // HV Dropper Cover
+	.duration(200).EUt(VA[HV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		metaitem('conveyor.module.ev'),
+		item('minecraft:dropper'),
+		ore('circuitEv'),
+		metaitem('electric.piston.ev')
+	)
+	.outputs(item('zbgt:zbgt_meta_item', 120)) // EV Dropper Cover
+	.duration(200).EUt(VA[EV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		metaitem('conveyor.module.iv'),
+		item('minecraft:dropper'),
+		ore('circuitIv'),
+		metaitem('electric.piston.iv')
+	)
+	.outputs(item('zbgt:zbgt_meta_item', 121)) // IV Dropper Cover
+	.duration(200).EUt(VA[IV])
+	.buildAndRegister()
+
+// Remove other unused blocks from JEI
+mods.jei.ingredient.removeAndHide(item('zbgt:misc_casing', 4)) // Compact Fusion Coil MK-II Prototype
+mods.jei.ingredient.removeAndHide(item('zbgt:misc_casing', 5)) // Compact Fusion Coil MK-II Finaltype
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 9)) // Component Assembly Line Casing (UHV)
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 10)) // Component Assembly Line Casing (UEV)
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 11)) // Component Assembly Line Casing (UIV)
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 12)) // Component Assembly Line Casing (UXV)
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 13)) // Component Assembly Line Casing (OpV)
+mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 14)) // Component Assembly Line Casing (MAX)

--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -247,7 +247,7 @@ mods.gregtech.assembler.recipeBuilder()
 		metaitem('plateTitanium') * 4
 	)
 	.outputs(item('zbgt:yottank_cell', 1))
-	.duration(100).EUt(VA[IV])
+	.duration(100).EUt(VA[EV])
 	.buildAndRegister()
 
 mods.gregtech.assembler.recipeBuilder()

--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -266,60 +266,60 @@ for(int i = 3; i <= 9; i++) {
 
 /* Unwrap craft for Wraps */
 def wraps = [
-	(item('zbgt:zbgt_meta_item', 57)): item('zbgt:zbgt_meta_item', 26), // Wrap of Generic ULV Circuit -> Generic ULV Circuit
-	(item('zbgt:zbgt_meta_item', 58)): item('zbgt:zbgt_meta_item', 27), // Wrap of Generic LV Circuit -> Generic LV Circuit
-	(item('zbgt:zbgt_meta_item', 59)): item('zbgt:zbgt_meta_item', 28), // Wrap of Generic MV Circuit -> Generic MV Circuit
-	(item('zbgt:zbgt_meta_item', 60)): item('zbgt:zbgt_meta_item', 29), // Wrap of Generic HV Circuit -> Generic HV Circuit
-	(item('zbgt:zbgt_meta_item', 61)): item('zbgt:zbgt_meta_item', 30), // Wrap of Generic EV Circuit -> Generic EV Circuit
-	(item('zbgt:zbgt_meta_item', 62)): item('zbgt:zbgt_meta_item', 31), // Wrap of Generic IV Circuit -> Generic IV Circuit
-	(item('zbgt:zbgt_meta_item', 63)): item('zbgt:zbgt_meta_item', 32), // Wrap of Generic LUV Circuit -> Generic LUV Circuit
-	(item('zbgt:zbgt_meta_item', 64)): item('zbgt:zbgt_meta_item', 33), // Wrap of Generic ZPM Circuit -> Generic ZPM Circuit
-	(item('zbgt:zbgt_meta_item', 65)): item('zbgt:zbgt_meta_item', 34), // Wrap of Generic UV Circuit -> Generic UV Circuit
-	(item('zbgt:zbgt_meta_item', 66)): item('zbgt:zbgt_meta_item', 35), // Wrap of Generic UHV Circuit -> Generic UHV Circuit
-	(item('zbgt:zbgt_meta_item', 72)): metaitem('component.smd.capacitor'), // Wrap of SMD Capacitor
-	(item('zbgt:zbgt_meta_item', 73)): metaitem('component.smd.diode'), // Wrap of SMD Diode
-	(item('zbgt:zbgt_meta_item', 74)): metaitem('component.smd.inductor'), // Wrap of SMD Inductor
-	(item('zbgt:zbgt_meta_item', 75)): metaitem('component.smd.resistor'), // Wrap of SMD Resistor
-	(item('zbgt:zbgt_meta_item', 76)): metaitem('component.smd.transistor'), // Wrap of SMD Transistor
-	(item('zbgt:zbgt_meta_item', 77)): metaitem('component.advanced_smd.capacitor'), // Wrap of Advanced SMD Capacitor
-	(item('zbgt:zbgt_meta_item', 78)): metaitem('component.advanced_smd.diode'), // Wrap of Advanced SMD Diode
-	(item('zbgt:zbgt_meta_item', 79)): metaitem('component.advanced_smd.inductor'), // Wrap of Advanced SMD Inductor
-	(item('zbgt:zbgt_meta_item', 80)): metaitem('component.advanced_smd.resistor'), // Wrap of Advanced SMD Resistor
-	(item('zbgt:zbgt_meta_item', 81)): metaitem('component.advanced_smd.transistor'), // Wrap of Advanced SMD Transistor
-	(item('zbgt:zbgt_meta_item', 82)): metaitem('board.coated'), // Wrap of Coated Circuit Board
-	(item('zbgt:zbgt_meta_item', 83)): metaitem('board.phenolic'), // Wrap of Phenolic Circuit Board
-	(item('zbgt:zbgt_meta_item', 84)): metaitem('board.plastic'), // Wrap of Plastic Circuit Board
-	(item('zbgt:zbgt_meta_item', 85)): metaitem('board.epoxy'), // Wrap of Epoxy Circuit Board
-	(item('zbgt:zbgt_meta_item', 86)): metaitem('board.fiber_reinforced'), // Wrap of Fiber Reinforced Circuit Board
-	(item('zbgt:zbgt_meta_item', 87)): metaitem('board.multilayer.fiber_reinforced'), // Wrap of Multilayer Fiber Reinforced Circuit Board
-	(item('zbgt:zbgt_meta_item', 88)): metaitem('board.wetware'), // Wrap of Wetware Circuit Board
-	(item('zbgt:zbgt_meta_item', 89)): metaitem('circuit_board.basic'), // Wrap of Basic Circuit Board
-	(item('zbgt:zbgt_meta_item', 90)): metaitem('circuit_board.good'), // Wrap of Good Circuit Board
-	(item('zbgt:zbgt_meta_item', 91)): metaitem('circuit_board.plastic'), // Wrap of Plastic Circuit Board
-	(item('zbgt:zbgt_meta_item', 92)): metaitem('circuit_board.advanced'), // Wrap of Advanced Circuit Board
-	(item('zbgt:zbgt_meta_item', 93)): metaitem('circuit_board.elite'), // Wrap of Elite Circuit Board
-	(item('zbgt:zbgt_meta_item', 94)): metaitem('circuit_board.extreme'), // Wrap of Extreme Circuit Board
-	(item('zbgt:zbgt_meta_item', 95)): metaitem('circuit_board.wetware'), // Wrap of Master Circuit Board
-	(item('zbgt:zbgt_meta_item', 96)): metaitem('plate.simple_system_on_chip'), // Wrap of Simple SoC
-	(item('zbgt:zbgt_meta_item', 97)): metaitem('plate.system_on_chip'), // Wrap of SoC
-	(item('zbgt:zbgt_meta_item', 98)): metaitem('plate.advanced_system_on_chip'), // Wrap of Advanced SoC
-	(item('zbgt:zbgt_meta_item', 99)): metaitem('plate.highly_advanced_system_on_chip'), // Wrap of Highly Advanced SoC
-	(item('zbgt:zbgt_meta_item', 100)): metaitem('plate.central_processing_unit'), // Wrap of CPU
-	(item('zbgt:zbgt_meta_item', 101)): metaitem('plate.nano_central_processing_unit'), // Wrap of Nano CPU
-	(item('zbgt:zbgt_meta_item', 102)): metaitem('plate.qbit_central_processing_unit'), // Wrap of Qubit CPU
-	(item('zbgt:zbgt_meta_item', 103)): metaitem('plate.ultra_low_power_integrated_circuit'), // Wrap of Ultra Low Power IC
-	(item('zbgt:zbgt_meta_item', 104)): metaitem('plate.low_power_integrated_circuit'), // Wrap of Low Power IC
-	(item('zbgt:zbgt_meta_item', 105)): metaitem('plate.power_integrated_circuit'), // Wrap of Power IC
-	(item('zbgt:zbgt_meta_item', 106)): metaitem('plate.high_power_integrated_circuit'), // Wrap of High Power IC
-	(item('zbgt:zbgt_meta_item', 107)): metaitem('plate.ultra_high_power_integrated_circuit'), // Wrap of Ultra High Power IC
-	(item('zbgt:zbgt_meta_item', 108)): metaitem('plate.random_access_memory'), // Wrap of RAM
-	(item('zbgt:zbgt_meta_item', 109)): metaitem('plate.nor_memory_chip'), // Wrap of NOR Chip
-	(item('zbgt:zbgt_meta_item', 110)): metaitem('plate.nand_memory_chip'), // Wrap of NAND Chip
-	(item('zbgt:zbgt_meta_item', 111)): metaitem('plate.integrated_logic_circuit'), // Wrap of Integrated Logic Circuit
-	(item('zbgt:zbgt_meta_item', 112)): metaitem('processor.neuro'), // Wrap of Neuro Processsing Unit
-	(item('zbgt:zbgt_meta_item', 113)): metaitem('engraved.crystal_chip'), // Wrap of Engraved Crystal Chip
-	(item('zbgt:zbgt_meta_item', 114)): metaitem('crystal.central_processing_unit'), // Wrap of Chrystal CPU
-	(item('zbgt:zbgt_meta_item', 115)): metaitem('crystal.system_on_chip') // Wrap of Crystal SoC
+	(metaitem('zbgt:wrapped.circuit.ulv')): metaitem('zbgt:generic_circuit.ulv'),
+	(metaitem('zbgt:wrapped.circuit.lv')): metaitem('zbgt:generic_circuit.lv'),
+	(metaitem('zbgt:wrapped.circuit.mv')): metaitem('zbgt:generic_circuit.mv'),
+	(metaitem('zbgt:wrapped.circuit.hv')): metaitem('zbgt:generic_circuit.hv'),
+	(metaitem('zbgt:wrapped.circuit.ev')): metaitem('zbgt:generic_circuit.ev'),
+	(metaitem('zbgt:wrapped.circuit.iv')): metaitem('zbgt:generic_circuit.iv'),
+	(metaitem('zbgt:wrapped.circuit.luv')): metaitem('zbgt:generic_circuit.luv'),
+	(metaitem('zbgt:wrapped.circuit.zpm')): metaitem('zbgt:generic_circuit.zpm'),
+	(metaitem('zbgt:wrapped.circuit.uv')): metaitem('zbgt:generic_circuit.uv'),
+	(metaitem('zbgt:wrapped.circuit.uhv')): metaitem('zbgt:generic_circuit.uhv'),
+	(metaitem('zbgt:wrapped.smd.capacitor')): metaitem('component.smd.capacitor'),
+	(metaitem('zbgt:wrapped.smd.diode')): metaitem('component.smd.diode'),
+	(metaitem('zbgt:wrapped.smd.inductor')): metaitem('component.smd.inductor'),
+	(metaitem('zbgt:wrapped.smd.resistor')): metaitem('component.smd.resistor'),
+	(metaitem('zbgt:wrapped.smd.transistor')): metaitem('component.smd.transistor'),
+	(metaitem('zbgt:wrapped.smd.advanced_capacitor')): metaitem('component.advanced_smd.capacitor'),
+	(metaitem('zbgt:wrapped.smd.advanced_diode')): metaitem('component.advanced_smd.diode'),
+	(metaitem('zbgt:wrapped.smd.advanced_inductor')): metaitem('component.advanced_smd.inductor'),
+	(metaitem('zbgt:wrapped.smd.advanced_resistor')): metaitem('component.advanced_smd.resistor'),
+	(metaitem('zbgt:wrapped.smd.advanced_transistor')): metaitem('component.advanced_smd.transistor'),
+	(metaitem('zbgt:wrapped.board.coated')): metaitem('board.coated'),
+	(metaitem('zbgt:wrapped.board.phenolic')): metaitem('board.phenolic'),
+	(metaitem('zbgt:wrapped.board.plastic')): metaitem('board.plastic'),
+	(metaitem('zbgt:wrapped.board.epoxy')): metaitem('board.epoxy'),
+	(metaitem('zbgt:wrapped.board.fiber_reinforced')): metaitem('board.fiber_reinforced'),
+	(metaitem('zbgt:wrapped.board.multilayer_fiber_reinforced')): metaitem('board.multilayer.fiber_reinforced'),
+	(metaitem('zbgt:wrapped.board.wetware')): metaitem('board.wetware'),
+	(metaitem('zbgt:wrapped.circuit_board.basic')): metaitem('circuit_board.basic'),
+	(metaitem('zbgt:wrapped.circuit_board.good')): metaitem('circuit_board.good'),
+	(metaitem('zbgt:wrapped.circuit_board.plastic')): metaitem('circuit_board.plastic'),
+	(metaitem('zbgt:wrapped.circuit_board.advanced')): metaitem('circuit_board.advanced'),
+	(metaitem('zbgt:wrapped.circuit_board.elite')): metaitem('circuit_board.elite'),
+	(metaitem('zbgt:wrapped.circuit_board.extreme')): metaitem('circuit_board.extreme'),
+	(metaitem('zbgt:wrapped.circuit_board.wetware')): metaitem('circuit_board.wetware'),
+	(metaitem('zbgt:wrapped.chip.soc_simple')): metaitem('plate.simple_system_on_chip'),
+	(metaitem('zbgt:wrapped.chip.soc')): metaitem('plate.system_on_chip'),
+	(metaitem('zbgt:wrapped.chip.soc_advanced')): metaitem('plate.advanced_system_on_chip'),
+	(metaitem('zbgt:wrapped.chip.soc_highly_advanced')): metaitem('plate.highly_advanced_system_on_chip'),
+	(metaitem('zbgt:wrapped.chip.cpu')): metaitem('plate.central_processing_unit'),
+	(metaitem('zbgt:wrapped.chip.cpu_nano')): metaitem('plate.nano_central_processing_unit'),
+	(metaitem('zbgt:wrapped.chip.cpu_qubit')): metaitem('plate.qbit_central_processing_unit'),
+	(metaitem('zbgt:wrapped.chip.pic_ultra_low')): metaitem('plate.ultra_low_power_integrated_circuit'),
+	(metaitem('zbgt:wrapped.chip.pic_low')): metaitem('plate.low_power_integrated_circuit'),
+	(metaitem('zbgt:wrapped.chip.pic')): metaitem('plate.power_integrated_circuit'),
+	(metaitem('zbgt:wrapped.chip.pic_high')): metaitem('plate.high_power_integrated_circuit'),
+	(metaitem('zbgt:wrapped.chip.pic_ultra_high')): metaitem('plate.ultra_high_power_integrated_circuit'),
+	(metaitem('zbgt:wrapped.chip.ram')): metaitem('plate.random_access_memory'),
+	(metaitem('zbgt:wrapped.chip.nor')): metaitem('plate.nor_memory_chip'),
+	(metaitem('zbgt:wrapped.chip.nand')): metaitem('plate.nand_memory_chip'),
+	(metaitem('zbgt:wrapped.chip.integrated_logic')): metaitem('plate.integrated_logic_circuit'),
+	(metaitem('zbgt:wrapped.misc.neuro_processor')): metaitem('processor.neuro'),
+	(metaitem('zbgt:wrapped.misc.engraved_crystal_chip')): metaitem('engraved.crystal_chip'),
+	(metaitem('zbgt:wrapped.misc.crystal_cpu')): metaitem('crystal.central_processing_unit'),
+	(metaitem('zbgt:wrapped.misc.crystal_soc')): metaitem('crystal.system_on_chip')
 ]
 
 wraps.each { wrap, output ->
@@ -334,58 +334,51 @@ wraps.each { wrap, output ->
 
 /* Cells */
 // Remove unused cells from JEI
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 133)) // 180K Space Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 134)) // 360K Space Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 135)) // 540K Space Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 136)) // 1080K Space Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 143)) // 180K SP Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 144)) // 360K SP Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 145)) // 540K SP Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 146)) // 1080K SP Coolant Cell
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.180k'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.360k'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.540k'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.1080k'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.180k_sp'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.360k_sp'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.540k_sp'))
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.1080k_sp'))
 
 // Remove unused filled cell recipes and from JEI
-mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 137)], null) // 60K HE Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 137))
-mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 138)], null) // 180K HE Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 138))
-mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 140)], null) // 60K NaK Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 140))
-mods.gregtech.canner.removeByOutput([item('zbgt:zbgt_meta_item', 141)], null) // 180K NaK Coolant Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 141))
+mods.gregtech.canner.removeByOutput([metaitem('zbgt:coolant_cell.60k.he')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.60k.he'))
+mods.gregtech.canner.removeByOutput([metaitem('zbgt:coolant_cell.180k.he')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.180k.he'))
+mods.gregtech.canner.removeByOutput([metaitem('zbgt:coolant_cell.60k.nak')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.60k.nak'))
+mods.gregtech.canner.removeByOutput([metaitem('zbgt:coolant_cell.180k.nak')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.180k.nak'))
 
 // Remove smaller single craft cells, and compley 60K cell craft
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 130)], null) // 10K Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 130))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 131)], null) // 30K Cell
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 131))
+mods.gregtech.assembler.removeByOutput([metaitem('zbgt:coolant_cell.10k')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.10k'))
+mods.gregtech.assembler.removeByOutput([metaitem('zbgt:coolant_cell.30k')], null)
+mods.jei.ingredient.removeAndHide(metaitem('zbgt:coolant_cell.30k'))
 
 mods.gregtech.assembler.removeByInput(120, [
-		item('zbgt:zbgt_meta_item', 131) * 2, // 30K Cell * 2
-		item('gregtech:meta_plate', 112) * 8, // Tin Plates * 8
+		metaitem('zbgt:coolant_cell.30k') * 2, // 30K Cell * 2
+		metaitem('plateTin') * 8, // Tin Plates * 8
 		metaitem('circuit.integrated').withNbt(['Configuration': 1])
 	], null)
 
 
 /* Dropper Cover Assembler recipes */
-def dropperCoverRecipes = [
-	'lv': item('zbgt:zbgt_meta_item', 117), // LV Dropper Cover
-	'mv': item('zbgt:zbgt_meta_item', 118), // MV Dropper Cover
-	'hv': item('zbgt:zbgt_meta_item', 119), // HV Dropper Cover
-	'ev': item('zbgt:zbgt_meta_item', 120), // EV Dropper Cover
-	'iv': item('zbgt:zbgt_meta_item', 121) // IV Dropper Cover
-]
-def eut = ['lv': VA[LV], 'mv': VA[MV], 'hv': VA[HV], 'ev': VA[EV], 'iv': VA[IV]]
+def dropperCoverTiers = ['lv': VA[LV], 'mv': VA[MV], 'hv': VA[HV], 'ev': VA[EV], 'iv': VA[IV]]
 
-dropperCoverRecipes.each { tier, output ->
+dropperCoverTiers.each { tier, eut ->
 	mods.gregtech.assembler.recipeBuilder()
 		.inputs(
-			metaitem("conveyor.module.${tier.toLowerCase()}"),
+			metaitem("conveyor.module.${tier}"),
 			item('minecraft:dropper'),
 			ore("circuit${tier.capitalize()}"),
-			metaitem("electric.piston.${tier.toLowerCase()}")
+			metaitem("electric.piston.${tier}")
 		)
-		.outputs(output)
-		.duration(200).EUt(eut[tier])
+		.outputs(metaitem("zbgt:cover.cover_dropper.${tier}"))
+		.duration(200).EUt(eut)
 		.buildAndRegister()
 }
 

--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -21,7 +21,6 @@ crafting.remove('zbgt:creative_energy_hatch_to_emitter')
 // Creative Item Bus (Useless since you already have chest)
 crafting.remove('zbgt:creative_item_bus_to_chest')
 crafting.remove('zbgt:creative_chest_to_item_bus')
-mods.jei.ingredient.removeAndHide(item('gregtech:machine', 18008)) // Creative Item Bus
 
 // Creative Tank
 crafting.remove('zbgt:creative_fluid_hatch_to_tank')
@@ -223,6 +222,7 @@ if (LabsModeHelper.normal) {
 		.buildAndRegister()
 }
 
+
 /* YOTTank Cells */
 // Add new recipes for YOTTank Cells
 mods.gregtech.assembler.recipeBuilder()
@@ -259,277 +259,78 @@ mods.gregtech.assembler.recipeBuilder()
 	.buildAndRegister()
 
 // Remove other YOTTank Cells from JEI
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 3))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 4))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 5))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 6))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 7))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 8))
-mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', 9))
+for(int i = 3; i <= 9; i++) {
+	mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', i))
+}
 
 
-/* Wraps */
-// Remove unused wrap crafts and from JEI
-// Wrap of Circuite board and SoC not removed, since other tiers have uses
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 57)], null) // Wrap of ULV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 57))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 58)], null) // Wrap of LV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 58))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 59)], null) // Wrap of MV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 59))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 60)], null) // Wrap of HV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 60))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 61)], null) // Wrap of EV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 61))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 62)], null) // Wrap of IV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 62))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 63)], null) // Wrap of LUV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 63))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 64)], null) // Wrap of ZPM Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 64))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 65)], null) // Wrap of UV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 65))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 66)], null) // Wrap of UHV Circuit
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 66))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 103)], null) // Wrap of PIC Ultra Low Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 103))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 104)], null) // Wrap of PIC Low Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 104))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 105)], null) // Wrap of PIC Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 105))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 106)], null) // Wrap of PIC High Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 106))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 107)], null) // Wrap of PIC Ultra High Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 107))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 111)], null) // Wrap of Integrated Logic Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 111))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 113)], null) // Wrap of Engraved Crystal Chip
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 113))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 82)], null) // Wrap of Coated Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 82))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 83)], null) // Wrap of Phenolic Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 83))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 84)], null) // Wrap of Plastic Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 84))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 85)], null) // Wrap of Epoxy Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 85))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 86)], null) // Wrap of Fiber Reinforced Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 86))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 87)], null) // Wrap of Multilayer Fiber Reinforced Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 87))
-mods.gregtech.assembler.removeByOutput([item('zbgt:zbgt_meta_item', 88)], null) // Wrap of Wetware Board
-mods.jei.ingredient.removeAndHide(item('zbgt:zbgt_meta_item', 88))
+/* Unwrap craft for Wraps */
+def wraps = [
+	(item('zbgt:zbgt_meta_item', 57)): item('zbgt:zbgt_meta_item', 26), // Wrap of Generic ULV Circuit -> Generic ULV Circuit
+	(item('zbgt:zbgt_meta_item', 58)): item('zbgt:zbgt_meta_item', 27), // Wrap of Generic LV Circuit -> Generic LV Circuit
+	(item('zbgt:zbgt_meta_item', 59)): item('zbgt:zbgt_meta_item', 28), // Wrap of Generic MV Circuit -> Generic MV Circuit
+	(item('zbgt:zbgt_meta_item', 60)): item('zbgt:zbgt_meta_item', 29), // Wrap of Generic HV Circuit -> Generic HV Circuit
+	(item('zbgt:zbgt_meta_item', 61)): item('zbgt:zbgt_meta_item', 30), // Wrap of Generic EV Circuit -> Generic EV Circuit
+	(item('zbgt:zbgt_meta_item', 62)): item('zbgt:zbgt_meta_item', 31), // Wrap of Generic IV Circuit -> Generic IV Circuit
+	(item('zbgt:zbgt_meta_item', 63)): item('zbgt:zbgt_meta_item', 32), // Wrap of Generic LUV Circuit -> Generic LUV Circuit
+	(item('zbgt:zbgt_meta_item', 64)): item('zbgt:zbgt_meta_item', 33), // Wrap of Generic ZPM Circuit -> Generic ZPM Circuit
+	(item('zbgt:zbgt_meta_item', 65)): item('zbgt:zbgt_meta_item', 34), // Wrap of Generic UV Circuit -> Generic UV Circuit
+	(item('zbgt:zbgt_meta_item', 66)): item('zbgt:zbgt_meta_item', 35), // Wrap of Generic UHV Circuit -> Generic UHV Circuit
+	(item('zbgt:zbgt_meta_item', 72)): metaitem('component.smd.capacitor'), // Wrap of SMD Capacitor
+	(item('zbgt:zbgt_meta_item', 73)): metaitem('component.smd.diode'), // Wrap of SMD Diode
+	(item('zbgt:zbgt_meta_item', 74)): metaitem('component.smd.inductor'), // Wrap of SMD Inductor
+	(item('zbgt:zbgt_meta_item', 75)): metaitem('component.smd.resistor'), // Wrap of SMD Resistor
+	(item('zbgt:zbgt_meta_item', 76)): metaitem('component.smd.transistor'), // Wrap of SMD Transistor
+	(item('zbgt:zbgt_meta_item', 77)): metaitem('component.advanced_smd.capacitor'), // Wrap of Advanced SMD Capacitor
+	(item('zbgt:zbgt_meta_item', 78)): metaitem('component.advanced_smd.diode'), // Wrap of Advanced SMD Diode
+	(item('zbgt:zbgt_meta_item', 79)): metaitem('component.advanced_smd.inductor'), // Wrap of Advanced SMD Inductor
+	(item('zbgt:zbgt_meta_item', 80)): metaitem('component.advanced_smd.resistor'), // Wrap of Advanced SMD Resistor
+	(item('zbgt:zbgt_meta_item', 81)): metaitem('component.advanced_smd.transistor'), // Wrap of Advanced SMD Transistor
+	(item('zbgt:zbgt_meta_item', 82)): metaitem('board.coated'), // Wrap of Coated Circuit Board
+	(item('zbgt:zbgt_meta_item', 83)): metaitem('board.phenolic'), // Wrap of Phenolic Circuit Board
+	(item('zbgt:zbgt_meta_item', 84)): metaitem('board.plastic'), // Wrap of Plastic Circuit Board
+	(item('zbgt:zbgt_meta_item', 85)): metaitem('board.epoxy'), // Wrap of Epoxy Circuit Board
+	(item('zbgt:zbgt_meta_item', 86)): metaitem('board.fiber_reinforced'), // Wrap of Fiber Reinforced Circuit Board
+	(item('zbgt:zbgt_meta_item', 87)): metaitem('board.multilayer.fiber_reinforced'), // Wrap of Multilayer Fiber Reinforced Circuit Board
+	(item('zbgt:zbgt_meta_item', 88)): metaitem('board.wetware'), // Wrap of Wetware Circuit Board
+	(item('zbgt:zbgt_meta_item', 89)): metaitem('circuit_board.basic'), // Wrap of Basic Circuit Board
+	(item('zbgt:zbgt_meta_item', 90)): metaitem('circuit_board.good'), // Wrap of Good Circuit Board
+	(item('zbgt:zbgt_meta_item', 91)): metaitem('circuit_board.plastic'), // Wrap of Plastic Circuit Board
+	(item('zbgt:zbgt_meta_item', 92)): metaitem('circuit_board.advanced'), // Wrap of Advanced Circuit Board
+	(item('zbgt:zbgt_meta_item', 93)): metaitem('circuit_board.elite'), // Wrap of Elite Circuit Board
+	(item('zbgt:zbgt_meta_item', 94)): metaitem('circuit_board.extreme'), // Wrap of Extreme Circuit Board
+	(item('zbgt:zbgt_meta_item', 95)): metaitem('circuit_board.wetware'), // Wrap of Master Circuit Board
+	(item('zbgt:zbgt_meta_item', 96)): metaitem('plate.simple_system_on_chip'), // Wrap of Simple SoC
+	(item('zbgt:zbgt_meta_item', 97)): metaitem('plate.system_on_chip'), // Wrap of SoC
+	(item('zbgt:zbgt_meta_item', 98)): metaitem('plate.advanced_system_on_chip'), // Wrap of Advanced SoC
+	(item('zbgt:zbgt_meta_item', 99)): metaitem('plate.highly_advanced_system_on_chip'), // Wrap of Highly Advanced SoC
+	(item('zbgt:zbgt_meta_item', 100)): metaitem('plate.central_processing_unit'), // Wrap of CPU
+	(item('zbgt:zbgt_meta_item', 101)): metaitem('plate.nano_central_processing_unit'), // Wrap of Nano CPU
+	(item('zbgt:zbgt_meta_item', 102)): metaitem('plate.qbit_central_processing_unit'), // Wrap of Qubit CPU
+	(item('zbgt:zbgt_meta_item', 103)): metaitem('plate.ultra_low_power_integrated_circuit'), // Wrap of Ultra Low Power IC
+	(item('zbgt:zbgt_meta_item', 104)): metaitem('plate.low_power_integrated_circuit'), // Wrap of Low Power IC
+	(item('zbgt:zbgt_meta_item', 105)): metaitem('plate.power_integrated_circuit'), // Wrap of Power IC
+	(item('zbgt:zbgt_meta_item', 106)): metaitem('plate.high_power_integrated_circuit'), // Wrap of High Power IC
+	(item('zbgt:zbgt_meta_item', 107)): metaitem('plate.ultra_high_power_integrated_circuit'), // Wrap of Ultra High Power IC
+	(item('zbgt:zbgt_meta_item', 108)): metaitem('plate.random_access_memory'), // Wrap of RAM
+	(item('zbgt:zbgt_meta_item', 109)): metaitem('plate.nor_memory_chip'), // Wrap of NOR Chip
+	(item('zbgt:zbgt_meta_item', 110)): metaitem('plate.nand_memory_chip'), // Wrap of NAND Chip
+	(item('zbgt:zbgt_meta_item', 111)): metaitem('plate.integrated_logic_circuit'), // Wrap of Integrated Logic Circuit
+	(item('zbgt:zbgt_meta_item', 112)): metaitem('processor.neuro'), // Wrap of Neuro Processsing Unit
+	(item('zbgt:zbgt_meta_item', 113)): metaitem('engraved.crystal_chip'), // Wrap of Engraved Crystal Chip
+	(item('zbgt:zbgt_meta_item', 114)): metaitem('crystal.central_processing_unit'), // Wrap of Chrystal CPU
+	(item('zbgt:zbgt_meta_item', 115)): metaitem('crystal.system_on_chip') // Wrap of Crystal SoC
+]
 
-// Add unwrap Crafts
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 72)) // Wrap of SMD Capacitor
-	.circuitMeta(1)
-	.outputs(metaitem('component.smd.capacitor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+wraps.each { wrap, output ->
+	mods.gregtech.assembler.recipeBuilder()
+		.inputs(wrap)
+		.circuitMeta(1)
+		.outputs(output * 16)
+		.duration(100).EUt(VA[LV])
+		.buildAndRegister()
+}
 
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 73)) // Wrap of SMD Diode
-	.circuitMeta(1)
-	.outputs(metaitem('component.smd.diode') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 74)) // Wrap of SMD Inductor
-	.circuitMeta(1)
-	.outputs(metaitem('component.smd.inductor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 75)) // Wrap of SMD Resistor
-	.circuitMeta(1)
-	.outputs(metaitem('component.smd.resistor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 76)) // Wrap of SMD Transistor
-	.circuitMeta(1)
-	.outputs(metaitem('component.smd.transistor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 77)) // Wrap of Advanced SMD Capacitor
-	.circuitMeta(1)
-	.outputs(metaitem('component.advanced_smd.capacitor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 78)) // Wrap of Advanced SMD Diode
-	.circuitMeta(1)
-	.outputs(metaitem('component.advanced_smd.diode') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 79)) // Wrap of Advanced SMD Inductor
-	.circuitMeta(1)
-	.outputs(metaitem('component.advanced_smd.inductor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 80)) // Wrap of Advanced SMD Resistor
-	.circuitMeta(1)
-	.outputs(metaitem('component.advanced_smd.resistor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 81)) // Wrap of Advanced SMD Transistor
-	.circuitMeta(1)
-	.outputs(metaitem('component.advanced_smd.transistor') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 89)) // Wrap of Basic Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.basic') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 90)) // Wrap of Good Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.good') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 91)) // Wrap of Plastic Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.plastic') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 92)) // Wrap of Advanced Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.advanced') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 93)) // Wrap of Elite Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.elite') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 94)) // Wrap of Extreme Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.extreme') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 95)) // Wrap of Master Circuit Board
-	.circuitMeta(1)
-	.outputs(metaitem('circuit_board.wetware') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 96)) // Wrap of Simple SoC
-	.circuitMeta(1)
-	.outputs(metaitem('plate.simple_system_on_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 97)) // Wrap of SoC
-	.circuitMeta(1)
-	.outputs(metaitem('plate.system_on_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 98)) // Wrap of Advanced SoC
-	.circuitMeta(1)
-	.outputs(metaitem('plate.advanced_system_on_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 99)) // Wrap of Highly Advanced SoC
-	.circuitMeta(1)
-	.outputs(metaitem('plate.highly_advanced_system_on_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 100)) // Wrap of CPU
-	.circuitMeta(1)
-	.outputs(metaitem('plate.central_processing_unit') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 101)) // Wrap of Nano CPU
-	.circuitMeta(1)
-	.outputs(metaitem('plate.nano_central_processing_unit') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 102)) // Wrap of Qubit CPU
-	.circuitMeta(1)
-	.outputs(metaitem('plate.qbit_central_processing_unit') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 108)) // Wrap of RAM
-	.circuitMeta(1)
-	.outputs(metaitem('plate.random_access_memory') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 109)) // Wrap of NOR Chip
-	.circuitMeta(1)
-	.outputs(metaitem('plate.nor_memory_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 110)) // Wrap of NAND Chip
-	.circuitMeta(1)
-	.outputs(metaitem('plate.nand_memory_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 112)) // Wrap of Neuro Processsing Unit
-	.circuitMeta(1)
-	.outputs(metaitem('processor.neuro') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 114)) // Wrap of Chrystal CPU
-	.circuitMeta(1)
-	.outputs(metaitem('crystal.central_processing_unit') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('zbgt:zbgt_meta_item', 115)) // Wrap of Crystal SoC
-	.circuitMeta(1)
-	.outputs(metaitem('crystal.system_on_chip') * 16)
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
 
 /* Cells */
 // Remove unused cells from JEI
@@ -564,65 +365,31 @@ mods.gregtech.assembler.removeByInput(120, [
 		metaitem('circuit.integrated').withNbt(['Configuration': 1])
 	], null)
 
+
 /* Dropper Cover Assembler recipes */
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		metaitem('conveyor.module.lv'),
-		item('minecraft:dropper'),
-		ore('circuitLv'),
-		metaitem('electric.piston.lv')
-	)
-	.outputs(item('zbgt:zbgt_meta_item', 117)) // LV Dropper Cover
-	.duration(200).EUt(VA[LV])
-	.buildAndRegister()
+def dropperCoverRecipes = [
+	'lv': item('zbgt:zbgt_meta_item', 117), // LV Dropper Cover
+	'mv': item('zbgt:zbgt_meta_item', 118), // MV Dropper Cover
+	'hv': item('zbgt:zbgt_meta_item', 119), // HV Dropper Cover
+	'ev': item('zbgt:zbgt_meta_item', 120), // EV Dropper Cover
+	'iv': item('zbgt:zbgt_meta_item', 121) // IV Dropper Cover
+]
+def eut = ['lv': VA[LV], 'mv': VA[MV], 'hv': VA[HV], 'ev': VA[EV], 'iv': VA[IV]]
 
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		metaitem('conveyor.module.mv'),
-		item('minecraft:dropper'),
-		ore('circuitMv'),
-		metaitem('electric.piston.mv')
-	)
-	.outputs(item('zbgt:zbgt_meta_item', 118)) // MV Dropper Cover
-	.duration(200).EUt(VA[MV])
-	.buildAndRegister()
+dropperCoverRecipes.each { tier, output ->
+	mods.gregtech.assembler.recipeBuilder()
+		.inputs(
+			metaitem("conveyor.module.${tier.toLowerCase()}"),
+			item('minecraft:dropper'),
+			ore("circuit${tier.capitalize()}"),
+			metaitem("electric.piston.${tier.toLowerCase()}")
+		)
+		.outputs(output)
+		.duration(200).EUt(eut[tier])
+		.buildAndRegister()
+}
 
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		metaitem('conveyor.module.hv'),
-		item('minecraft:dropper'),
-		ore('circuitHv'),
-		metaitem('electric.piston.hv')
-	)
-	.outputs(item('zbgt:zbgt_meta_item', 119)) // HV Dropper Cover
-	.duration(200).EUt(VA[HV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		metaitem('conveyor.module.ev'),
-		item('minecraft:dropper'),
-		ore('circuitEv'),
-		metaitem('electric.piston.ev')
-	)
-	.outputs(item('zbgt:zbgt_meta_item', 120)) // EV Dropper Cover
-	.duration(200).EUt(VA[EV])
-	.buildAndRegister()
-
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		metaitem('conveyor.module.iv'),
-		item('minecraft:dropper'),
-		ore('circuitIv'),
-		metaitem('electric.piston.iv')
-	)
-	.outputs(item('zbgt:zbgt_meta_item', 121)) // IV Dropper Cover
-	.duration(200).EUt(VA[IV])
-	.buildAndRegister()
-
-// Remove other unused blocks from JEI
-mods.jei.ingredient.removeAndHide(item('zbgt:misc_casing', 4)) // Compact Fusion Coil MK-II Prototype
-mods.jei.ingredient.removeAndHide(item('zbgt:misc_casing', 5)) // Compact Fusion Coil MK-II Finaltype
+// Remove higher tier blocks from JEI
 mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 9)) // Component Assembly Line Casing (UHV)
 mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 10)) // Component Assembly Line Casing (UEV)
 mods.jei.ingredient.removeAndHide(item('zbgt:coal_casing', 11)) // Component Assembly Line Casing (UIV)

--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -5,6 +5,9 @@ package postInit.addon
 
 import com.nomiceu.nomilabs.util.LabsModeHelper
 
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
+
 import static gregtech.api.GTValues.*
 
 // TODO: Implement the Creative computing hatch and Creative data hatch
@@ -225,23 +228,23 @@ if (LabsModeHelper.normal) {
 
 /* YOTTank Cells */
 // Add new recipes for YOTTank Cells
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(
-		item('gregtech:hermetic_casing', 0),
-		metaitem('field.generator.lv'),
-		ore('circuitLv') * 4,
-		metaitem('plateSteel') * 4
-	)
-	.outputs(item('zbgt:yottank_cell', 0))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+crafting.shapedBuilder().name('zbgt:yottank_cell_0')
+	.output(item('zbgt:yottank_cell', 0))
+	.matrix('SFS'
+		   ,'SHS'
+		   ,'SCS')
+	.key('S', metaitem('plateSteel'))
+	.key('F', metaitem('field.generator.lv'))
+	.key('H', item('gregtech:hermetic_casing', 0))
+	.key('C', ore('circuitLv'))
+	.register()
 
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(
-		item('gregtech:hermetic_casing', 4),
+		item('gregtech:hermetic_casing', 3),
 		metaitem('field.generator.hv') * 2,
-		ore('circuitIv') * 4,
-		metaitem('plateTungstenSteel') * 4
+		ore('circuitEv') * 4,
+		metaitem('plateTitanium') * 4
 	)
 	.outputs(item('zbgt:yottank_cell', 1))
 	.duration(100).EUt(VA[IV])
@@ -249,19 +252,53 @@ mods.gregtech.assembler.recipeBuilder()
 
 mods.gregtech.assembler.recipeBuilder()
 	.inputs(
+		item('gregtech:hermetic_casing', 5),
+		metaitem('field.generator.iv') * 2,
+		ore('circuitLuv') * 4,
+		metaitem('plateRhodiumPlatedPalladium') * 4
+	)
+	.fluidInputs(fluid('tin') * (144 * 4))
+	.outputs(item('zbgt:yottank_cell', 2))
+	.duration(100).EUt(VA[LuV])
+	.buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(
+		item('gregtech:hermetic_casing', 5),
+		metaitem('field.generator.iv') * 2,
+		ore('circuitLuv') * 4,
+		metaitem('plateRhodiumPlatedPalladium') * 4
+	)
+	.fluidInputs(fluid('soldering_alloy') * (144 * 2))
+	.outputs(item('zbgt:yottank_cell', 2))
+	.duration(100).EUt(VA[LuV])
+	.buildAndRegister()
+
+mods.gregtech.assembly_line.recipeBuilder()
+	.inputs(
 		item('gregtech:hermetic_casing', 8),
 		metaitem('field.generator.uv') * 2,
-		ore('circuitUv') * 4,
-		metaitem('plateNeutronium') * 4
+		ore('circuitUhv') * 4,
+		metaitem('plateEuropium') * 8
 	)
-	.outputs(item('zbgt:yottank_cell', 2))
+	.fluidInputs(fluid('soldering_alloy') * (144 * 8), fluid('polybenzimidazole') * (144 * 8))
+	.outputs(item('zbgt:yottank_cell', 3))
+	.stationResearch(b -> b.researchStack(item('zbgt:yottank_cell', 2)).CWUt(16).EUt(VA[UV]))
 	.duration(100).EUt(VA[UV])
 	.buildAndRegister()
 
+
 // Remove other YOTTank Cells from JEI
-for(int i = 3; i <= 9; i++) {
+for(int i = 4; i <= 9; i++) {
 	mods.jei.ingredient.removeAndHide(item('zbgt:yottank_cell', i))
 }
+
+// Add tooltips to YOTTank Cells
+addTooltip(item('zbgt:yottank_cell', 0), [
+	translatableEmpty(),
+	translatable('nomiceu.tooltip.yottank_cell.yottank_cell.1'),
+	translatable('nomiceu.tooltip.yottank_cell.yottank_cell.2')
+])
 
 
 /* Unwrap craft for Wraps */

--- a/overrides/groovy/postInit/addon/zbgt.groovy
+++ b/overrides/groovy/postInit/addon/zbgt.groovy
@@ -230,9 +230,9 @@ if (LabsModeHelper.normal) {
 // Add new recipes for YOTTank Cells
 crafting.shapedBuilder().name('zbgt:yottank_cell_0')
 	.output(item('zbgt:yottank_cell', 0))
-	.matrix('SFS'
-		   ,'SHS'
-		   ,'SCS')
+	.matrix('SFS',
+			'SHS',
+			'SCS')
 	.key('S', metaitem('plateSteel'))
 	.key('F', metaitem('field.generator.lv'))
 	.key('H', item('gregtech:hermetic_casing', 0))

--- a/overrides/resources/zbgt/lang/en_us.lang
+++ b/overrides/resources/zbgt/lang/en_us.lang
@@ -5,4 +5,4 @@ tile.yottank_cell.yottank_cell_3.name=Fluid Cell Block T2
 tile.yottank_cell.yottank_cell_4.name=Fluid Cell Block T3
 
 nomiceu.tooltip.yottank_cell.yottank_cell.1=For filling space in your YOTTank.
-nomiceu.tooltip.yottank_cell.yottank_cell.2=You probaly want to use T1 or higher for actual storage.
+nomiceu.tooltip.yottank_cell.yottank_cell.2=You probably want to use T1 or higher for actual storage.

--- a/overrides/resources/zbgt/lang/en_us.lang
+++ b/overrides/resources/zbgt/lang/en_us.lang
@@ -1,0 +1,8 @@
+# between line 453 to 459 in jar file
+tile.yottank_cell.yottank_cell_1.name=Fluid Cell Block T0
+tile.yottank_cell.yottank_cell_2.name=Fluid Cell Block T1
+tile.yottank_cell.yottank_cell_3.name=Fluid Cell Block T2
+tile.yottank_cell.yottank_cell_4.name=Fluid Cell Block T3
+
+nomiceu.tooltip.yottank_cell.yottank_cell.1=For filling space in your YOTTank.
+nomiceu.tooltip.yottank_cell.yottank_cell.2=You probaly want to use T1 or higher for actual storage.


### PR DESCRIPTION
Expanded version of the ZBGT addon script, implementing missing crafts with general cleanup

### JEI Cleanup
Removed Creative Item Bus from JEI, since the craft was already removed
Removed items without crafts and uses:
- Compact Fusion Coil MK-II
- Component Assembly Line Casing
- Cooland and SP Cells

### Wrap of _\#_
Removed crafts for Wraps with no uses, and hidden them from JEI
Exception are the lower tier Wrap of Circuite Boards and Wrap of Simple SoC, since higher tiers have viable uses, so it's better to keep them in line.

Added "unwrap" recipes for each Wrap in the assembler giving back the original 16 components

### Cells
Having no other uses I removed the smaller than 60K cells and the crafts for filling them.
The 60K cell already had an assembler recipe from normal gregtech empty cells, so I left only that one in.

### Dropper Cover
Added Assembler recipes for dropper cover LV to IV which previously only had normal crafts requiring a wrench.
The assembler recipes should be easier to automate with AE2.

### YOTTank
Previously every part of the YOTTank were craftable, exept the fluid Cell Blocks themself, wich meant the multiblock were unusable.

I have given an assembler craft for Fluid Cell Blocks T1-3. I balanced those around the single block tanks:
- Fluid Cell T1 &harr; Super Tank I
- Fluid Cell T2 &harr; Super Tank V
- Fluid Cell T3 &harr; Quantum Tank V

The tier 4-10 fluid cells were hidden from jei.

My philosopy was, T2-3 already give a quite big amout of fluid capacity, and if needing more, you can alwasy make more levels. for the multiblock.
This makes them inline with single-block tanks, without making them obsolite, and having a more interesting upgrade curve than just crafting bigger capacity,

It all makes the YOTTank quite balanced in my opinion. You can make a useful YOTTank at around from IV tech, meaning late midgame to early late-game

### Considerations
#### Bigger Parallel Hatches
I considered hiding and removing the recipe for higher than OpV Parallel Hatch (×65536 parallel), since these require voltage tiers available only with creative power in this pack.
But since there is a way for creative power i left them in.

#### Creative computing hatch, Creative data hatch
There is an active TODO in the file to implement the Creative computing hatch and Creative data hatch
I don't feel comfortable enough to give these balanced recipes, since I never played in survival until creative.
I did't hide them in JEI, since I feel like these could be part of the script at a different later PR