### PR TITLE
Add AE2 Crafting Tree

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -753,6 +753,11 @@
       "projectID": 1058274,
       "fileID": 5531643,
       "required": true
+    },
+    {
+      "projectID": 1121489,
+      "fileID":5814089,
+      "required": true
     }
   ]
 }

--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -58466,6 +58466,45 @@
           "taskID:8": "bq_standard:retrieval"
         }
       }
+    },
+    "1112:10": {
+      "preRequisites:11": [
+        809
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "autoclaim:1": 0,
+          "desc:8": "§bAE2 Crafting Tree§r is the ultimate way to debug your patterns, and to show off your AE2 crafts to your friends and enemies.\n\nTo access it, simply request a craft, and before pressing start, click on the small icon on the top right of the GUI. This will display your craft in a tree-like way.\n\nEven better, if you have missing items, then the display will automatically show only the items you are missing, making debugging easy. You can turn the display to show all items by clicking the red button on the top right.",
+          "globalshare:1": 0,
+          "icon:10": {
+            "Count:3": 1,
+            "Damage:2": 0,
+            "OreDict:8": "",
+            "id:8": "minecraft:sapling"
+          },
+          "ignoresview:1": 0,
+          "ismain:1": 1,
+          "issilent:1": 0,
+          "lockedprogress:1": 0,
+          "name:8": "AE2 Crafting Tree",
+          "questlogic:8": "AND",
+          "repeat_relative:1": 1,
+          "repeattime:3": -1,
+          "simultaneous:1": 0,
+          "snd_complete:8": "minecraft:entity.player.levelup",
+          "snd_update:8": "minecraft:entity.player.levelup",
+          "tasklogic:8": "AND",
+          "visibility:8": "ALWAYS"
+        }
+      },
+      "questID:3": 1112,
+      "rewards:9": {},
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "taskID:8": "bq_standard:checkbox"
+        }
+      }
     }
   },
   "questLines:9": {
@@ -64988,7 +65027,7 @@
           "id:3": 404,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 144,
+          "x:3": 186,
           "y:3": 744
         },
         "34:10": {
@@ -65107,7 +65146,7 @@
           "id:3": 935,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 186,
+          "x:3": 228,
           "y:3": 744
         },
         "51:10": {
@@ -65277,6 +65316,13 @@
           "sizeY:3": 24,
           "x:3": 102,
           "y:3": 696
+        },
+        "75:10": {
+          "id:3": 1112,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 144,
+          "y:3": 744
         }
       }
     }

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -67534,6 +67534,45 @@
           "taskID:8": "bq_standard:retrieval"
         }
       }
+    },
+    "1096:10": {
+      "preRequisites:11": [
+        967
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "autoclaim:1": 0,
+          "desc:8": "§bAE2 Crafting Tree§r is the ultimate way to debug your patterns, and to show off your AE2 crafts to your friends and enemies.\n\nTo access it, simply request a craft, and before pressing start, click on the small icon on the top right of the GUI. This will display your craft in a tree-like way.\n\nEven better, if you have missing items, then the display will automatically show only the items you are missing, making debugging easy. You can turn the display to show all items by clicking the red button on the top right.",
+          "globalshare:1": 0,
+          "icon:10": {
+            "Count:3": 1,
+            "Damage:2": 0,
+            "OreDict:8": "",
+            "id:8": "minecraft:sapling"
+          },
+          "ignoresview:1": 0,
+          "ismain:1": 1,
+          "issilent:1": 0,
+          "lockedprogress:1": 0,
+          "name:8": "AE2 Crafting Tree",
+          "questlogic:8": "AND",
+          "repeat_relative:1": 1,
+          "repeattime:3": -1,
+          "simultaneous:1": 0,
+          "snd_complete:8": "minecraft:entity.player.levelup",
+          "snd_update:8": "minecraft:entity.player.levelup",
+          "tasklogic:8": "AND",
+          "visibility:8": "ALWAYS"
+        }
+      },
+      "questID:3": 1096,
+      "rewards:9": {},
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "taskID:8": "bq_standard:checkbox"
+        }
+      }
     }
   },
   "questLines:9": {
@@ -74098,7 +74137,7 @@
           "id:3": 404,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 90,
+          "x:3": 132,
           "y:3": 696
         },
         "32:10": {
@@ -74134,7 +74173,7 @@
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
-          "y:3": 660
+          "y:3": 624
         },
         "37:10": {
           "id:3": 784,
@@ -74218,7 +74257,7 @@
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
-          "y:3": 696
+          "y:3": 660
         },
         "49:10": {
           "id:3": 1032,
@@ -74387,6 +74426,13 @@
           "sizeY:3": 24,
           "x:3": 48,
           "y:3": 660
+        },
+        "73:10": {
+          "id:3": 1096,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 90,
+          "y:3": 696
         }
       }
     },

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -67534,6 +67534,45 @@
           "taskID:8": "bq_standard:retrieval"
         }
       }
+    },
+    "1096:10": {
+      "preRequisites:11": [
+        967
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "autoclaim:1": 0,
+          "desc:8": "§bAE2 Crafting Tree§r is the ultimate way to debug your patterns, and to show off your AE2 crafts to your friends and enemies.\n\nTo access it, simply request a craft, and before pressing start, click on the small icon on the top right of the GUI. This will display your craft in a tree-like way.\n\nEven better, if you have missing items, then the display will automatically show only the items you are missing, making debugging easy. You can turn the display to show all items by clicking the red button on the top right.",
+          "globalshare:1": 0,
+          "icon:10": {
+            "Count:3": 1,
+            "Damage:2": 0,
+            "OreDict:8": "",
+            "id:8": "minecraft:sapling"
+          },
+          "ignoresview:1": 0,
+          "ismain:1": 1,
+          "issilent:1": 0,
+          "lockedprogress:1": 0,
+          "name:8": "AE2 Crafting Tree",
+          "questlogic:8": "AND",
+          "repeat_relative:1": 1,
+          "repeattime:3": -1,
+          "simultaneous:1": 0,
+          "snd_complete:8": "minecraft:entity.player.levelup",
+          "snd_update:8": "minecraft:entity.player.levelup",
+          "tasklogic:8": "AND",
+          "visibility:8": "ALWAYS"
+        }
+      },
+      "questID:3": 1096,
+      "rewards:9": {},
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "taskID:8": "bq_standard:checkbox"
+        }
+      }
     }
   },
   "questLines:9": {
@@ -74098,7 +74137,7 @@
           "id:3": 404,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 90,
+          "x:3": 132,
           "y:3": 696
         },
         "32:10": {
@@ -74134,7 +74173,7 @@
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
-          "y:3": 660
+          "y:3": 624
         },
         "37:10": {
           "id:3": 784,
@@ -74218,7 +74257,7 @@
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
-          "y:3": 696
+          "y:3": 660
         },
         "49:10": {
           "id:3": 1032,
@@ -74387,6 +74426,13 @@
           "sizeY:3": 24,
           "x:3": 48,
           "y:3": 660
+        },
+        "73:10": {
+          "id:3": 1096,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 90,
+          "y:3": 696
         }
       }
     },

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -58466,6 +58466,45 @@
           "taskID:8": "bq_standard:retrieval"
         }
       }
+    },
+    "1112:10": {
+      "preRequisites:11": [
+        809
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "autoclaim:1": 0,
+          "desc:8": "§bAE2 Crafting Tree§r is the ultimate way to debug your patterns, and to show off your AE2 crafts to your friends and enemies.\n\nTo access it, simply request a craft, and before pressing start, click on the small icon on the top right of the GUI. This will display your craft in a tree-like way.\n\nEven better, if you have missing items, then the display will automatically show only the items you are missing, making debugging easy. You can turn the display to show all items by clicking the red button on the top right.",
+          "globalshare:1": 0,
+          "icon:10": {
+            "Count:3": 1,
+            "Damage:2": 0,
+            "OreDict:8": "",
+            "id:8": "minecraft:sapling"
+          },
+          "ignoresview:1": 0,
+          "ismain:1": 1,
+          "issilent:1": 0,
+          "lockedprogress:1": 0,
+          "name:8": "AE2 Crafting Tree",
+          "questlogic:8": "AND",
+          "repeat_relative:1": 1,
+          "repeattime:3": -1,
+          "simultaneous:1": 0,
+          "snd_complete:8": "minecraft:entity.player.levelup",
+          "snd_update:8": "minecraft:entity.player.levelup",
+          "tasklogic:8": "AND",
+          "visibility:8": "ALWAYS"
+        }
+      },
+      "questID:3": 1112,
+      "rewards:9": {},
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "taskID:8": "bq_standard:checkbox"
+        }
+      }
     }
   },
   "questLines:9": {
@@ -64988,7 +65027,7 @@
           "id:3": 404,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 144,
+          "x:3": 186,
           "y:3": 744
         },
         "34:10": {
@@ -65107,7 +65146,7 @@
           "id:3": 935,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 186,
+          "x:3": 228,
           "y:3": 744
         },
         "51:10": {
@@ -65277,6 +65316,13 @@
           "sizeY:3": 24,
           "x:3": 102,
           "y:3": 696
+        },
+        "75:10": {
+          "id:3": 1112,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 144,
+          "y:3": 744
         }
       }
     }

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -1119,6 +1119,10 @@
     {
       "normal": 1095,
       "expert": 1111
+    },
+    {
+      "normal": 1096,
+      "expert": 1112
     }
   ],
   "ignoreQuestsNormal": [


### PR DESCRIPTION
This PR adds AE2 Crafting Tree v0.1.2, as well as a corresponding quest detailing its features in Matter Energy.

This mod allows for (very) nice viewing of (especially complex) crafts, and improves the ability of players to debug their crafts.