### PR TITLE
Add Tooltip to Fission Reactor Port

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/tooltips.groovy
+++ b/overrides/groovy/postInit/main/general/misc/tooltips.groovy
@@ -310,6 +310,12 @@ for (MetadataLivingMatter matter : MetadataManager.livingMatterMetadataList) {
 /* NuclearCraft */
 addTooltip(item('nuclearcraft:fission_controller_new_fixed'), translatable('nomiceu.tooltip.nc.fission_safe'))
 
+// Tooltip to Port: Prevent Confusion with Active Coolers
+addTooltip(item('nuclearcraft:fission_port'), [
+	translatable('nomiceu.tooltip.nc.fission_port_warning'),
+	translatable('nomiceu.tooltip.nc.fission_port_redirect'),
+])
+
 /* Thermal Expansion */
 
 // Capacitors

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -128,6 +128,8 @@ nomiceu.tooltip.labs.hand_framing.bottom_left=§5Bottom Left: §oFront§r
 nomiceu.tooltip.nc.nbt_clearing.cooler.can_clear=Place in Crafting Grid to §eClear Coolant§r!
 nomiceu.tooltip.nc.nbt_clearing.cooler.warning=§cCoolant Will be Voided!§r
 nomiceu.tooltip.nc.fission_safe=§aSafe! Does not meltdown!§r
+nomiceu.tooltip.nc.fission_port_warning=§cNot Used for Fueling Active Coolers!§r
+nomiceu.tooltip.nc.fission_port_redirect=Buffers are Used Instead.
 
 # Storage Drawers, Framed Compacting Drawers & GregTech Drawers
 nomiceu.tooltip.drawers.nbt_clearing.drawers.can_clear.1=Place in Crafting Grid to §eClear Contents§r!


### PR DESCRIPTION
This PR adds a tooltip to NC’s Fission Reactor Port, stating that it is not used for fueling active coolers, reducing confusion from players.