### PR TITLE
Add Rhodochrosite Recipes for Nether/End Ores

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/nuclearcraft.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/nuclearcraft.groovy
@@ -1,6 +1,7 @@
 package postInit.main.modSpecific
 
 import com.nomiceu.nomilabs.util.ItemMeta
+import gregtech.api.unification.OreDictUnifier
 import mezz.jei.api.ingredients.VanillaTypes
 import nc.enumm.MetaEnums
 import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient
@@ -109,6 +110,31 @@ for (var fuel : fuelMetas) {
 				return stack
 			}.replaceAndRegister()
 	}
+}
+
+/* Crushed Rhodochrosite from Redstone & Pyrolusite */
+var oreInputs = [
+	(oreprefix('ore')): 2, // Double Ore Req for Normal Ore
+	(oreprefix('oreNetherrack')): 1,
+	(oreprefix('oreEndstone')): 1,
+]
+
+for (var input : oreInputs) {
+	mods.gregtech.large_chemical_reactor.recipeBuilder()
+		.outputs(item('nuclearcraft:gem_dust', 1))
+		.inputs(OreDictUnifier.get(input.key, material('pyrolusite')) * (3 * input.value))
+		.fluidInputs(fluid('sulfuric_acid') * 3000)
+		.fluidOutputs(fluid('manganese') * 4320)
+		.duration(200).EUt(VA[EV])
+		.buildAndRegister()
+
+	mods.gregtech.large_chemical_reactor.recipeBuilder()
+		.outputs(item('nuclearcraft:gem_dust', 1))
+		.inputs(OreDictUnifier.get(input.key, material('redstone')) * (6 * input.value))
+		.fluidInputs(fluid('sulfuric_acid') * 6000)
+		.fluidOutputs(fluid('redstone') * 19008)
+		.duration(200).EUt(VA[EV])
+		.buildAndRegister()
 }
 
 // Change Active Cooler Recipe from NC Helium -> GT Liquid Helium

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -536,22 +536,6 @@ alloy.recipeBuilder()
     .inputs([<nuclearcraft:alloy:2>, <ore:ingotTough>])
     .duration(200).EUt(1000).buildAndRegister();
 
-
-
-large_chemical_reactor.recipeBuilder()
-    .outputs(<nuclearcraft:gem_dust:1>)
-    .inputs([<ore:orePyrolusite> * 6])
-    .fluidInputs([<liquid:sulfuric_acid> * 3000])
-    .fluidOutputs([<liquid:manganese> * 4320])
-    .duration(200).EUt(2000).buildAndRegister();
-
-large_chemical_reactor.recipeBuilder()
-    .outputs(<nuclearcraft:gem_dust:1>)
-    .inputs([<ore:oreRedstone> * 12])
-    .fluidInputs([<liquid:sulfuric_acid> * 6000])
-    .fluidOutputs([<liquid:redstone> * 19008])
-    .duration(200).EUt(2000).buildAndRegister();
-
 reactor.recipeBuilder().inputs([<nomilabs:t2laser>])
     .outputs(<nomilabs:t3laser>)
     .fluidInputs([<liquid:radon> * 1000])


### PR DESCRIPTION
This PR adds recipes for Crushed Rhodochrosite, with nether/end variants of Pyrolusite and Redstone. These use half the ore amount compared to the normal recipes, fitting in with the general trend that these ores provide double materials.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1358.