### PR TITLE
Update Nomi Labs to v0.15.4, HEI to v4.28.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -610,7 +610,7 @@
     },
     {
       "projectID": 557549,
-      "fileID": 6187146,
+      "fileID": 6463525,
       "required": true
     },
     {
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6438352,
+      "fileID": 6650610,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs from v0.15.1 to v0.15.4, as well as updating HEI to v4.28.0, which is required for this update.

Changes:

# Bug Fixes
## AE2
- **Fixes Cross Dimension Energy P2Ps not functioning properly after world load**
- Fixes Issues when Right Clicking Adv Memory Card Mode Button
- Fixes Incorrect Items being allowed in Quantum Link Card slot

## JEI
- ABS structure displaying with a HV Muffler Hatch

## Internal
- Fixes GrS Hand giving incorrect information for GT MetaItems from GT Addons

# Features
## AE2
- **Craft Overview Sorting**: Placing missing items first, then items to craft, then present items
- Information about connection status of Quantum Link Chambers in TOP
- Advanced Memory Card's Add as Input/Output modes now work across P2P types, auto-converting the selected P2P to the bind target's type

## GT
- Gold Cell, adding more GT acid proof fluid storage options

## JEI
- Custom ItemStack Count Renderer, improving display of item stacks in JEI above 100
- General Performance Improvements

## Internal
- Adds more versatile tooltip helpers

# Issues Fixed
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1338
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1323