### PR TITLE
Nerf Outputs of ME Conduit Recipes

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -4451,7 +4451,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cable§r for those.",
+          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types, but they are more expensive to make, and §ccan sometimes cause connection issues§r, so use them wisely and only when needed.\n\nThey also §ewill not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use §6Fluix Cables§r for those.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/normal/betterquesting/DefaultQuests.json
@@ -5304,7 +5304,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cables§r for those. §2Furthermore, they are known to sometimes disconnect from machine hulls and full-block interfaces, so use AE cables like §6Fluix Cables§r for those.",
+          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types, but they are more expensive to make, and §ccan sometimes cause connection issues§r, so use them wisely and only when needed.\n\nThey also §ewill not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use §6Fluix Cables§r for those.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -5304,7 +5304,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cables§r for those. §2Furthermore, they are known to sometimes disconnect from machine hulls and full-block interfaces, so use AE cables like §6Fluix Cables§r for those.",
+          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types, but they are more expensive to make, and §ccan sometimes cause connection issues§r, so use them wisely and only when needed.\n\nThey also §ewill not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use §6Fluix Cables§r for those.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -4451,7 +4451,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cable§r for those.",
+          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types, but they are more expensive to make, and §ccan sometimes cause connection issues§r, so use them wisely and only when needed.\n\nThey also §ewill not connect to §bApplied Energistics §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use §6Fluix Cables§r for those.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/groovy/postInit/main/modSpecific/ae2/blocks.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/ae2/blocks.groovy
@@ -174,15 +174,6 @@ for (var rubber in [fluid('rubber') * 144, fluid('styrene_butadiene_rubber') * 3
 		.buildAndRegister()
 }
 
-// ME Conduit
-crafting.removeByOutput(item('enderio:item_me_conduit'))
-mods.gregtech.assembler.recipeBuilder()
-	.inputs(item('appliedenergistics2:part', 36) * 3, item('enderio:item_material', 4) * 6)
-	.outputs(item('enderio:item_me_conduit') * 8)
-	.duration(100).EUt(VHA[LV])
-	.buildAndRegister()
-
-
 /* Block Parts */
 /* Planes */
 var makePlane = { OreDictIngredient plate, ItemStack core, ItemStack plane ->

--- a/overrides/groovy/postInit/main/modSpecific/eio.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/eio.groovy
@@ -4,6 +4,8 @@ import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
 import net.minecraft.item.ItemStack
 import classes.postInit.Common
 
+import static gregtech.api.GTValues.*
+
 /* Cleanup EIO Glasses in JEI, removing the dyed versions of each variant of glass
  * Since we are lazy, remove all, then add back the original
  */
@@ -14,11 +16,25 @@ for (var stack in Common.eioGlasses) {
 
 // ME Conduit - Crafting Table
 crafting.shapedBuilder()
-	.output(item('enderio:item_me_conduit') * 4)
+	.output(item('enderio:item_me_conduit'))
 	.matrix('BBB', 'PPP', 'BBB')
 	.key('B', ore('itemConduitBinder'))
 	.key('P', item('appliedenergistics2:part', 36))
 	.replace().register()
+
+// ME Conduit
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('appliedenergistics2:part', 36) * 3, item('enderio:item_material', 4) * 6)
+	.outputs(item('enderio:item_me_conduit') * 2)
+	.duration(100).EUt(VHA[LV])
+	.buildAndRegister()
+
+// Dense ME Conduit - Assembler
+mods.gregtech.assembler.recipeBuilder()
+	.inputs(item('enderio:item_me_conduit') * 4, ore('itemConduitBinder') * 5)
+	.outputs(item('enderio:item_me_conduit', 1) * 2)
+	.duration(80).EUt(VHA[LV])
+	.buildAndRegister();
 
 // Replace the 'old' Glowstone nano particles with the 'not old' one
 // Not really serving any purpose, but removing the need for two items that do the same thing

--- a/overrides/scripts/AppliedEnergistics2.zs
+++ b/overrides/scripts/AppliedEnergistics2.zs
@@ -11,11 +11,3 @@ makeShaped("me_controller", <appliedenergistics2:controller>,
 	{ F : <ore:crystalPureFluix>,
 	  P : <ore:plateDarkSteel>,
 	  A : <appliedenergistics2:energy_acceptor>});
-
-// Dense Conduit
-assembler.recipeBuilder()
-	.inputs([<enderio:item_me_conduit> * 4, <ore:itemConduitBinder> * 5])
-	.outputs([<enderio:item_me_conduit:1> * 2])
-	.duration(80)
-	.EUt(16)
-	.buildAndRegister();

--- a/tools/storage/savedQBPorter.json
+++ b/tools/storage/savedQBPorter.json
@@ -113,6 +113,10 @@
       "expert": 72
     },
     {
+      "normal": 73,
+      "expert": 73
+    },
+    {
       "normal": 78,
       "expert": 78
     },


### PR DESCRIPTION
This PR reduces the amount of ME Conduits created from the recipes:
1 from crafting (taking 3 covered cables, down from 4)
2 from assembler (taking 3 covered cables, down from 8)

This incentivises the use of Glass Cables, and deincentivizes the use of ME Conduits.

Fixes #1321