### PR TITLE
Standardise Tooltips for Covers and Pipes

### DIFF
--- a/overrides/groovy/classes/postInit/common.groovy
+++ b/overrides/groovy/classes/postInit/common.groovy
@@ -1,5 +1,6 @@
 package classes.postInit
 
+import gregtech.api.GTValues
 import net.minecraft.item.ItemStack
 import org.apache.commons.lang3.tuple.Pair
 
@@ -8,6 +9,23 @@ class Common {
 	private static ItemStack meP2p = null
 	private static List<Pair<String, ItemStack>> p2pVariants = null
 	private static List<ItemStack> eioGlasses = null
+	private static List<String> voltageNames = null
+
+	/**
+	 * Gets a continuous sublist of GregTech Voltage Names, in lowercase. Do not modify the returned list.
+	 * @param from The start index of the sublist. Inclusive.
+	 * @param to The end index of the sublist. Inclusive.
+ 	 */
+	static List<String> getVoltageNames(int from, int to) {
+		if (voltageNames == null) {
+			voltageNames = new ArrayList<>()
+			for (var voltage : GTValues.VN) {
+				voltageNames.add(voltage.toLowerCase())
+			}
+		}
+
+		return voltageNames.subList(from, to + 1)
+	}
 
 	static ItemStack getMeP2p() {
 		if (meP2p != null) return meP2p

--- a/overrides/groovy/postInit/main/general/misc/tooltips.groovy
+++ b/overrides/groovy/postInit/main/general/misc/tooltips.groovy
@@ -7,10 +7,18 @@ import appeng.core.AEConfig
 import appeng.core.features.AEFeature
 import com.nomiceu.nomilabs.config.LabsConfig
 import com.nomiceu.nomilabs.util.LabsModeHelper
+import gregtech.api.GregTechAPI
+import gregtech.api.unification.OreDictUnifier
+import gregtech.api.unification.material.properties.PropertyKey
+import gregtech.api.util.TextFormattingUtil
+import gregtech.common.pipelike.fluidpipe.BlockFluidPipe
+import gregtech.common.pipelike.fluidpipe.ItemBlockFluidPipe
 import mustapelto.deepmoblearning.common.metadata.MetadataLivingMatter
 import mustapelto.deepmoblearning.common.metadata.MetadataManager
 import net.minecraft.item.ItemStack
 
+import static gregtech.api.unification.ore.OrePrefix.*
+import static gregtech.api.GTValues.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TooltipHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 import classes.postInit.Common
@@ -341,6 +349,45 @@ for (ItemStack prospector in [metaitem('prospector.lv'), metaitem('prospector.hv
 addTooltip(metaitem('cover.facade'), [
 	translatable('nomiceu.tooltip.gregtech.facade')
 ])
+
+// Pipes
+// Change Unit in Tooltips to L/s
+var fluidPipePrefixes = [pipeTinyFluid, pipeSmallFluid, pipeNormalFluid,pipeLargeFluid, pipeHugeFluid,
+						 pipeQuadrupleFluid, pipeNonupleFluid]
+for (var material : GregTechAPI.materialManager.registeredMaterials) {
+	if (!material.hasProperty(PropertyKey.FLUID_PIPE)) continue
+
+	for (var prefix : fluidPipePrefixes) {
+		ItemStack pipe = OreDictUnifier.get(prefix, material)
+		// Wood & Treated Wood Pipes don't have tiny, huge, quad and nonuple
+		if (pipe.empty) continue
+
+		var pipeBlock = (BlockFluidPipe) ((ItemBlockFluidPipe) pipe.getItem()).block
+
+		var prop = pipeBlock.createItemProperties(pipe)
+		String transferAmt = TextFormattingUtil.formatNumbers(prop.getThroughput() * 20)
+
+		customHandleTooltip(pipe, {
+			it.subList(0, 1).clear() // Remove first
+			it.add(0,translatable('nomiceu.tooltip.gregtech.transfer_l_s', transferAmt).translate())
+		})
+	}
+}
+
+// Pumps
+// Change Unit in Tooltips to L/s
+var tiers = Common.getVoltageNames(LV, UV)
+for (int i = 0; i < tiers.size(); i++) {
+	String tier = tiers[i]
+	long transferAmt = 1280 * (long) Math.pow(4, i)
+
+	String transferFmt = TextFormattingUtil.formatNumbers(transferAmt)
+
+	customHandleTooltip(metaitem("electric.pump.${tier}"), {
+		it.subList(it.size() - 1, it.size()).clear() // Remove last
+		it.add(translatable('nomiceu.tooltip.gregtech.transfer_l_s', transferFmt).translate())
+	})
+}
 
 /* Ender IO */
 

--- a/overrides/groovy/postInit/main/general/misc/tooltips.groovy
+++ b/overrides/groovy/postInit/main/general/misc/tooltips.groovy
@@ -350,6 +350,26 @@ addTooltip(metaitem('cover.facade'), [
 	translatable('nomiceu.tooltip.gregtech.facade')
 ])
 
+// ULV Covers
+// Change tooltips to match other covers
+customHandleTooltip(metaitem('ulv_covers:conveyor.module.ulv')) {
+	it.clear()
+	it.add(translate('metaitem.conveyor.module.tooltip'))
+	it.add(translate('gregtech.universal.tooltip.item_transfer_rate', 4))
+}
+
+customHandleTooltip(metaitem('ulv_covers:robot.arm.ulv')) {
+	it.clear()
+	it.add(translate('metaitem.robot.arm.tooltip'))
+	it.add(translate('gregtech.universal.tooltip.item_transfer_rate', 4))
+}
+
+customHandleTooltip(metaitem('ulv_covers:electric.pump.ulv')) {
+	it.clear()
+	it.add(translate('metaitem.electric.pump.tooltip'))
+	it.add(translate('nomiceu.tooltip.gregtech.transfer_l_s', 320))
+}
+
 // Pipes
 // Change Unit in Tooltips to L/s
 var fluidPipePrefixes = [pipeTinyFluid, pipeSmallFluid, pipeNormalFluid,pipeLargeFluid, pipeHugeFluid,
@@ -367,10 +387,10 @@ for (var material : GregTechAPI.materialManager.registeredMaterials) {
 		var prop = pipeBlock.createItemProperties(pipe)
 		String transferAmt = TextFormattingUtil.formatNumbers(prop.getThroughput() * 20)
 
-		customHandleTooltip(pipe, {
+		customHandleTooltip(pipe) {
 			it.subList(0, 1).clear() // Remove first
-			it.add(0,translatable('nomiceu.tooltip.gregtech.transfer_l_s', transferAmt).translate())
-		})
+			it.add(0, translate('nomiceu.tooltip.gregtech.transfer_l_s', transferAmt))
+		}
 	}
 }
 
@@ -383,10 +403,10 @@ for (int i = 0; i < tiers.size(); i++) {
 
 	String transferFmt = TextFormattingUtil.formatNumbers(transferAmt)
 
-	customHandleTooltip(metaitem("electric.pump.${tier}"), {
+	customHandleTooltip(metaitem("electric.pump.${tier}")) {
 		it.subList(it.size() - 1, it.size()).clear() // Remove last
-		it.add(translatable('nomiceu.tooltip.gregtech.transfer_l_s', transferFmt).translate())
-	})
+		it.add(translate('nomiceu.tooltip.gregtech.transfer_l_s', transferFmt))
+	}
 }
 
 /* Ender IO */

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -107,6 +107,7 @@ nomiceu.tooltip.gregtech.prospector.2=Grid squares = 1 chunk, up is north.
 nomiceu.tooltip.gregtech.prospector.3=Click an ore in the sidebar to isolate it.
 nomiceu.tooltip.gregtech.prospector.4=Use JEI to check the potential vein depth.
 nomiceu.tooltip.gregtech.facade=§3GTCEu facades can be made from most non-tile-entities.§r
+nomiceu.tooltip.gregtech.transfer_l_s=§bTransfer Rate:§r %sL/s
 
 # Ender IO
 nomiceu.tooltip.eio.fused_glass.make=Made with §6Tempered Glass§r and §7White Dye§r


### PR DESCRIPTION
This PR aims to improve the standardisation of the tooltips for both covers and pipes.

## ULV Covers
- Tooltips match GT's base covers

## Pumps and Pipes
- Tooltips changed to L/s, to match item transfer rates (measured in items/s or stacks/s) and pump GUIs

Fixes #1348 