### PR TITLE
Add Extruder Recipes from Polymer Pulps to Rods/Blocks

### DIFF
--- a/overrides/groovy/postInit/main/general/misc/pulps.groovy
+++ b/overrides/groovy/postInit/main/general/misc/pulps.groovy
@@ -1,0 +1,43 @@
+import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
+import gregtech.api.recipes.ingredients.GTRecipeItemInput
+import gregtech.api.unification.OreDictUnifier
+
+import static gregtech.api.unification.material.Materials.*
+import static gregtech.api.unification.ore.OrePrefix.*
+
+/* Add Extruder Recipes from Pulps to Blocks/Rods */
+
+// Polymer Materials (Skipping Raw Rubber, no blocks or rods)
+var materials = [
+    Rubber,
+	SiliconeRubber,
+	StyreneButadieneRubber,
+	Epoxy,
+	ReinforcedEpoxyResin,
+	Polyethylene,
+	PolyvinylChloride,
+	Polytetrafluoroethylene,
+	Polybenzimidazole,
+	PolyphenyleneSulfide,
+	Polycaprolactam,
+]
+
+var prefixes = [
+    block,
+	stick,
+]
+
+for (def material : materials) {
+	var dust = OreDictUnifier.get(dust, material)
+	for (def prefix : prefixes) {
+		var stack = OreDictUnifier.get(prefix, material)
+		if (stack.empty) continue
+
+		mods.gregtech.extruder.changeByOutput([stack], null)
+			.forEach { ChangeRecipeBuilder builder ->
+				builder.changeInputs {
+					it.set(0, new GTRecipeItemInput(dust))
+				}.buildAndRegister()
+			}
+	}
+}


### PR DESCRIPTION
This PR adds extruder recipes from pulps of polymers to blocks and rods.

These were the only extruder recipes for polymers that only allowed bars, and disallowed pulps.

QoL: Allow players to only solidify plates.