### PR TITLE
Update Nomi Labs to v0.15.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6700853,
+      "fileID": 6731800,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Labs to v0.15.8, fixing a small bug with the new incl consume option.