### PR TITLE
Change Byproduct of Snowchestite from Chalcopyrite to Caesium

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6731800,
+      "fileID": 6731975,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs to v0.15.9, changing the main byproduct of Snowchestite from Chalcopyrite to Caesium.

This was previously done in https://github.com/Nomi-CEu/Nomi-CEu/commit/3e0e67925734a18afd00f89871fe3f09dae07a1e, but the change was not reflected in Labs, and so it was lost during the migration.