### PR TITLE
Improvement to 'Add As' Modes in Adv Mem Card

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6731975,
+      "fileID": 6736934,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs to v0.15.10, improving the versatility and use cases of the 'add as' modes, essentially meaning it replaces most functions of the 'bind as' modes. It is thus now the default. ‘Bind As’ modes have been given new functionality, by guaranteeing that a new seperate network is created.

Also, adds new helpers to the change recipe builder.