### PR TITLE
Cleanup AdvRocketry GrS

### DIFF
--- a/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
+++ b/overrides/groovy/postInit/main/modSpecific/advancedRocketry.groovy
@@ -16,9 +16,6 @@ mods.enderio.enchanter.recipeBuilder()
 	.register()
 
 // Recipes for Industrial Rebreather Kit
-int airtightId = Enchantment.getEnchantmentID(enchantment('advancedrocketry:spacebreathing'))
-ItemStack airtight = item('minecraft:enchanted_book').withNbt(['StoredEnchantments': [['id': (short) airtightId, 'lvl': (short) 1]]])
-
 if (LabsModeHelper.normal) {
 	mods.gregtech.assembler.recipeBuilder()
 		.inputs(


### PR DESCRIPTION
This PR removes two unused variables in advanced rocketry’s grs script.