### PR TITLE
Fix Missing Plutonium 239 Block in JEI

### DIFF
--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -196,7 +196,7 @@ var blocksDisabled as IItemStack[][IOreDictEntry] = {
 
 	#blockPlutonium
 	<ore:blockPlutonium> : [
-		<metaitem:blockPlutonium>
+//		<metaitem:blockPlutonium>
 	],
 
 	#blockPulsatingIron


### PR DESCRIPTION
This PR fixes the Plutonium 239 Block missing from JEI; causing weird alloy smelter (and more) recipes for plutonium 239.