### PR TITLE
New Network Visualization Tool Recipe

### DIFF
--- a/overrides/groovy/post/main/mod/ae2/items.groovy
+++ b/overrides/groovy/post/main/mod/ae2/items.groovy
@@ -39,6 +39,20 @@ crafting.shapelessBuilder()
     .input(ore('itemIlluminatedPanel'), item('actuallyadditions:item_laser_wrench'))
     .replace().register()
 
+// Network Visualisation Tool
+crafting.shapedBuilder()
+    .output(item('ae2stuff:visualiser'))
+    .matrix(
+        'S S',
+        'EPE',
+        'FFF'
+    )
+    .key('S', metaitem('sensor.lv'))
+    .key('P', ore('itemIlluminatedPanel'))
+    .key('E', item('appliedenergistics2:material', 24))
+    .key('F', item('appliedenergistics2:material', 12))
+    .register()
+
 /* Materials */
 // Pattern
 crafting.shapedBuilder()

--- a/overrides/groovy/post/main/mod/ae2/items.groovy
+++ b/overrides/groovy/post/main/mod/ae2/items.groovy
@@ -45,8 +45,7 @@ crafting.shapedBuilder()
     .matrix(
         'S S',
         'EPE',
-        'FFF'
-    )
+        'FFF')
     .key('S', metaitem('sensor.lv'))
     .key('P', ore('itemIlluminatedPanel'))
     .key('E', item('appliedenergistics2:material', 24))


### PR DESCRIPTION
The network visualization tool is currently EV gated, it's not really useful to gate it this far, as the only thing it does is help people who did turn channels on visualize their channels. I put it at MV, adding an alternate recipe using LV sensors.

I put this in the AE2 directory, since AE2Stuff adds a grand total of 4 items. This is opinionated so let me know if you think it should go elsewhere.

Old vs. New Recipe. Keeps both to not break patterns.
<img width="250" height="254" alt="image" src="https://github.com/user-attachments/assets/ad50d02f-b92d-4241-9bdf-8cd61edb692c" />
