### PR TITLE
Allow Void World / Lost Cities in Air Collector Circ 1

### DIFF
--- a/overrides/groovy/post/main/general/early/earlygame.groovy
+++ b/overrides/groovy/post/main/general/early/earlygame.groovy
@@ -445,7 +445,7 @@ mods.gregtech.gas_collector.changeByOutput(null, [fluid('air') * 10000])
 
         // LEGACY: Circuit 4 for Void World / Lost Cities
         builder.copyOriginal()
-            .changeCircuitMeta {4 }
+            .changeCircuitMeta { 4 }
             .builder { GasCollectorRecipeBuilder recipe ->
                 // Don't copy properties or add overworld dim to keep legacy behaviour
                 recipe.dimension(119) // Void World

--- a/overrides/groovy/post/main/general/early/earlygame.groovy
+++ b/overrides/groovy/post/main/general/early/earlygame.groovy
@@ -13,6 +13,7 @@ import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilderCollection
 import com.nomiceu.nomilabs.groovy.RecipePredicates
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import gregtech.api.recipes.builders.SimpleRecipeBuilder
+import gregtech.api.recipes.builders.GasCollectorRecipeBuilder
 import gregtech.client.utils.TooltipHelper
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fluids.FluidStack
@@ -430,3 +431,24 @@ for (var pair : dustsAndFuels) {
         .duration(100).EUt(VA[LV])
         .buildAndRegister()
 }
+
+// Gas Collector in Void World / Lost Cities
+mods.gregtech.gas_collector.changeByOutput(null, [fluid('air') * 10000])
+    .forEach { ChangeRecipeBuilder builder ->
+        builder.builder { GasCollectorRecipeBuilder recipe ->
+            // Re-add the overworld dimension as it is lost during changeByOutput
+            // We could perform copyProperties but this is easier
+            recipe.dimension(0) // Overworld
+                .dimension(119) // Void World
+                .dimension(111) // Lost Cities
+        }.replaceAndRegister()
+
+        // LEGACY: Circuit 4 for Void World / Lost Cities
+        builder.copyOriginal()
+            .changeCircuitMeta {4 }
+            .builder { GasCollectorRecipeBuilder recipe ->
+                // Don't copy properties or add overworld dim to keep legacy behaviour
+                recipe.dimension(119) // Void World
+                    .dimension(111) // Lost Cities
+            }.buildAndRegister()
+    }

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -98,16 +98,6 @@ vacuum_freezer.recipeBuilder()
 	.EUt(6000)
 	.buildAndRegister();
 
-// Allow Gas Collector to work in LostCities, void dims
-gas_collector.recipeBuilder()
-	.fluidOutputs(<liquid:air> * 10000)
-	.circuit(4)
-	.property("dimension", 111)
-	.property("dimension", 119)
-	.duration(200)
-	.EUt(16)
-	.buildAndRegister();
-
 canner.recipeBuilder()
 	.inputs(<minecraft:glass_bottle>)
 	.fluidInputs(<liquid:xpjuice> * 500)


### PR DESCRIPTION
This PR allows circuit 1 to be used for overworld, void world and lost cities, reducing player confusion.

Circuit 4 for void world / lost cities has been kept for legacy compatibility purposes.

Should it be a hidden recipe?