### PR TITLE
Slightly Increase Speed of Diamond/Obsidian Furnace

### DIFF
--- a/overrides/config/morefurnaces.cfg
+++ b/overrides/config/morefurnaces.cfg
@@ -3,16 +3,16 @@
 general {
     D:copperFurnaceConsumptionRate=2.0
     I:copperFurnaceSpeed=100
-    D:diamondFurnaceConsumptionRate=8.0
-    I:diamondFurnaceSpeed=25
+    D:diamondFurnaceConsumptionRate=10.0
+    I:diamondFurnaceSpeed=20
     D:goldFurnaceConsumptionRate=5.0
     I:goldFurnaceSpeed=40
     D:ironFurnaceConsumptionRate=1.33
     I:ironFurnaceSpeed=150
     D:netherrackFurnaceConsumptionRate=1.0
     I:netherrackFurnaceSpeed=1800
-    D:obsidianFurnaceConsumptionRate=8.0
-    I:obsidianFurnaceSpeed=25
+    D:obsidianFurnaceConsumptionRate=10.0
+    I:obsidianFurnaceSpeed=20
     D:silverFurnaceConsumptionRate=3.33
     I:silverFurnaceSpeed=60
 }


### PR DESCRIPTION
With the previous consumption rate multiplier of 8, through the logic of the te, the consumption rate per tick would be fuel burn rates divided by 8. Examples:

`WOOL: 100/8 = 12.5`
`STICK: 100/8 = 12.5`
`LOGS: 300/8 = 37.5`

This is then rounded down. This resulted in certain fuels being less efficient for diamond/obsidian furnaces.

This PR increases the consumption rate multiplier to 10, and the speed accordingly decreasing to 20. This should result in a clean division for essentially all fuels.

(Partially) Fixes #1577


